### PR TITLE
correctie gegeven stap

### DIFF
--- a/features/zoek-met-burgerservicenummer/gba/autorisatie-gba.feature
+++ b/features/zoek-met-burgerservicenummer/gba/autorisatie-gba.feature
@@ -30,8 +30,6 @@ Functionaliteit: autorisatie voor het gebruik van de API ZoekMetBurgerservicenum
       | soort reisdocument (35.10)                                              | PN        |
       | nummer reisdocument (35.20)                                             | NE3663258 |
       | datum einde geldigheid reisdocument (35.50)                             | 20240506  |
-      | datum inhouding dan wel vermissing Nederlands reisdocument (35.60)      | 20230405  |
-      | aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70) | I         |
       En de persoon heeft de volgende 'verblijfplaats' gegevens
       | gemeente van inschrijving (09.10) |
       | 0800                              |


### PR DESCRIPTION
correctie gegeven stap: ZoekMetBurgerservicenummer levert alleen reisdocumenten die niet zijn ingeleverd, dus moet Gegeven een reisdocument bevatten dat niet is ingeleverd.

N.a.v. #90 
> Toegevoegd 02-05-2023
> ...
> Achtergrond en scenario matchen niet.
>
> Scenario: Gemeente zoekt reisdocumenten van een eigen inwoner door het opgeven van eigen gemeentecode als gemeenteVanInschrijving # features\zoek-met-burgerservicenummer\gba\autorisatie-gba.feature:45