### PR TITLE
Fix: verwijderen gemeente van inschrijving parameter

### DIFF
--- a/features/fields-fout-cases.feature
+++ b/features/fields-fout-cases.feature
@@ -7,10 +7,9 @@ Rule: De fields parameter is een verplichte parameter
   @fout-case
   Abstract Scenario: De fields parameter ontbreekt
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde             |
-    | type                    | <zoek type>        |
-    | <parameter naam>        | <parameter waarde> |
-    | gemeenteVanInschrijving | 0800               |
+    | naam             | waarde             |
+    | type             | <zoek type>        |
+    | <parameter naam> | <parameter waarde> |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -33,11 +32,10 @@ Rule: De fields parameter bevat een lijst met minimaal één veld pad
   @fout-case
   Abstract Scenario: De fields parameter bevat een lege lijst
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde             |
-    | type                    | <zoek type>        |
-    | <parameter naam>        | <parameter waarde> |
-    | gemeenteVanInschrijving | 0800               |
-    | fields                  |                    |
+    | naam             | waarde             |
+    | type             | <zoek type>        |
+    | <parameter naam> | <parameter waarde> |
+    | fields           |                    |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -60,11 +58,10 @@ Rule: De fields parameter bevat een lijst met maximaal 25 veld paden
   @fout-case
   Scenario: De fields parameter bevat meer dan 25 veld paden
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-    | type                    | <zoek type>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-    | <parameter naam>        | <parameter waarde>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-    | gemeenteVanInschrijving | 0800                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-    | fields                  | reisdocumentnummer,soort,soort.code,soort.omschrijving,datumEindeGeldigheid,datumEindeGeldigheid.type,datumEindeGeldigheid.datum,houder,houder.burgerservicenummer,inhoudingOfVermissing,inhoudingOfVermissing.aanduiding,inhoudingOfVermissing.datum,reisdocumentnummer,soort,soort.code,soort.omschrijving,datumEindeGeldigheid,datumEindeGeldigheid.type,datumEindeGeldigheid.datum,houder,houder.burgerservicenummer,inhoudingOfVermissing,inhoudingOfVermissing.aanduiding,inhoudingOfVermissing.datum,reisdocumentnummer,reisdocumentnummer |
+    | naam             | waarde                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+    | type             | <zoek type>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+    | <parameter naam> | <parameter waarde>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+    | fields           | reisdocumentnummer,soort,soort.code,soort.omschrijving,datumEindeGeldigheid,datumEindeGeldigheid.type,datumEindeGeldigheid.datum,houder,houder.burgerservicenummer,inhoudingOfVermissing,inhoudingOfVermissing.aanduiding,inhoudingOfVermissing.datum,reisdocumentnummer,soort,soort.code,soort.omschrijving,datumEindeGeldigheid,datumEindeGeldigheid.type,datumEindeGeldigheid.datum,houder,houder.burgerservicenummer,inhoudingOfVermissing,inhoudingOfVermissing.aanduiding,inhoudingOfVermissing.datum,reisdocumentnummer,reisdocumentnummer |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -91,11 +88,10 @@ Rule: De fields parameter bevat veld paden die verwijzen naar een bestaand veld.
   @fout-case
   Abstract Scenario: De fields parameter bevat één of meerdere veld paden met ongeldige karakters
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde             |
-    | type                    | <zoek type>        |
-    | <parameter naam>        | <parameter waarde> |
-    | gemeenteVanInschrijving | 0800               |
-    | fields                  | <fields>           |
+    | naam             | waarde             |
+    | type             | <zoek type>        |
+    | <parameter naam> | <parameter waarde> |
+    | fields           | <fields>           |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -120,11 +116,10 @@ Rule: De fields parameter bevat veld paden die verwijzen naar een bestaand veld.
   @fout-case
   Abstract Scenario: De fields parameter bevat één of meerdere niet bestaande (onjuiste case) veld paden
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde             |
-    | type                    | <zoek type>        |
-    | <parameter naam>        | <parameter waarde> |
-    | gemeenteVanInschrijving | 0800               |
-    | fields                  | <fields>           |
+    | naam             | waarde             |
+    | type             | <zoek type>        |
+    | <parameter naam> | <parameter waarde> |
+    | fields           | <fields>           |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -149,11 +144,10 @@ Rule: Automatisch geleverde velden mogen niet worden gevraagd
   @fout-case
   Abstract Scenario: De fields parameter bevat één of meerdere paden van automatisch geleverde velden
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde             |
-    | type                    | <zoek type>        |
-    | <parameter naam>        | <parameter waarde> |
-    | gemeenteVanInschrijving | 0800               |
-    | fields                  | <fields>           |
+    | naam             | waarde             |
+    | type             | <zoek type>        |
+    | <parameter naam> | <parameter waarde> |
+    | fields           | <fields>           |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |

--- a/features/raadpleeg-met-reisdocumentnummer/fields.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/fields.feature
@@ -16,22 +16,20 @@ Functionaliteit: Reisdocument velden vragen met fields
 
   Scenario: 'nummer reisdocument (35.20)' wordt gevraagd met field pad 'reisdocumentnummer'
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer             |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | reisdocumentnummer             |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde    |
     | reisdocumentnummer | NE3663258 |
 
   Abstract Scenario: 'soort reisdocument (35.10)' wordt gevraagd met field pad '<field>'
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | <field>                        |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | <field>                        |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde             |
     | soort.code         | PN                 |
@@ -45,11 +43,10 @@ Functionaliteit: Reisdocument velden vragen met fields
 
   Abstract Scenario: 'datum einde geldigheid reisdocument (35.50)' wordt gevraagd met field pad '<field>'
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | <field>                        |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | <field>                        |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam                             | waarde     |
     | datumEindeGeldigheid.type        | Datum      |
@@ -68,11 +65,10 @@ Functionaliteit: Reisdocument velden vragen met fields
 
   Abstract Scenario: 'datum inhouding dan wel vermissing Nederlands reisdocument (35.60)' wordt gevraagd met field pad 'inhoudingOfVermissing.<field>'
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | inhoudingOfVermissing.<field>  |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | inhoudingOfVermissing.<field>  |
     Dan heeft de response een 'reisdocument' met de volgende 'inhoudingOfVermissing' gegevens
     | naam              | waarde       |
     | datum.type        | Datum        |
@@ -91,11 +87,10 @@ Functionaliteit: Reisdocument velden vragen met fields
 
   Abstract Scenario: 'aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70)' wordt gevraagd met field pad 'inhoudingOfVermissing.<field>'
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | inhoudingOfVermissing.<field>  |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | inhoudingOfVermissing.<field>  |
     Dan heeft de response een 'reisdocument' met de volgende 'inhoudingOfVermissing' gegevens
     | naam                    | waarde                   |
     | aanduiding.code         | I                        |
@@ -109,11 +104,10 @@ Functionaliteit: Reisdocument velden vragen met fields
 
   Scenario: 'burgerservicenummer' van houder wordt gevraagd met field pad 'houder.burgerservicenummer'
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | houder.burgerservicenummer     |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | houder.burgerservicenummer     |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                | waarde    |
     | burgerservicenummer | 000000152 |

--- a/features/raadpleeg-met-reisdocumentnummer/fout-cases.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/fout-cases.feature
@@ -100,7 +100,6 @@ Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden 
     | naam                    | waarde                         |
     | type                    | RaadpleegMetReisdocumentnummer |
     | reisdocumentnummer      | AB1234567                      |
-    | gemeenteVanInschrijving | 0800                           |
     | <parameter>             | <waarde>                       |
     | fields                  | reisdocumentnummer             |
     Dan heeft de response een object met de volgende gegevens

--- a/features/raadpleeg-met-reisdocumentnummer/fout-cases.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/fout-cases.feature
@@ -7,10 +7,9 @@ Rule: De reisdocumentnummer parameter is een verplichte parameter
   @fout-case
   Scenario: De reisdocumentnummer parameter is niet opgegeven
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer             |
+    | naam   | waarde                         |
+    | type   | RaadpleegMetReisdocumentnummer |
+    | fields | reisdocumentnummer             |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -28,11 +27,10 @@ Rule: De reisdocumentnummer parameter bevat een lijst met minimaal één reisdoc
   @fout-case
   Abstract Scenario: De reisdocumentnummer parameter bevat een lege lijst
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      |                                |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer             |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer |                                |
+    | fields             | reisdocumentnummer             |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -50,11 +48,10 @@ Rule: Een reisdocumentnummer is een string bestaande uit exact 9 cijfers en hoof
   @fout-case
   Abstract Scenario: <titel>
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | <reisdocumentnummers>          |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer             |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | <reisdocumentnummers>          |
+    | fields             | reisdocumentnummer             |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -79,11 +76,10 @@ Rule: De reisdocumentnummer parameter bevat een lijst van maximaal 1 reisdocumen
   @fout-case
   Scenario: De reisdocumentnummer parameter bevat meer dan 1 reisdocumentnummer
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | AB1234567,BC8901234            |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer             |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | AB1234567,BC8901234            |
+    | fields             | reisdocumentnummer             |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -95,56 +91,6 @@ Rule: De reisdocumentnummer parameter bevat een lijst van maximaal 1 reisdocumen
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name               | reason                        |
     | maxItems | reisdocumentnummer | Array bevat meer dan 1 items. |
-
-Rule: De gemeenteVanInschrijving parameter is een verplichte parameter
-
-  @fout-case
-  Scenario: De gemeenteVanInschrijving parameter is niet opgegeven
-    Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam               | waarde                         |
-    | type               | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer | NE3663258                      |
-    | fields             | reisdocumentnummer             |
-    Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Een of meerdere parameters zijn niet correct.               |
-    | status   | 400                                                         |
-    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-    | code     | paramsValidation                                            |
-    | instance | /haalcentraal/api/reisdocumenten/reisdocumenten             |
-    En heeft het object de volgende 'invalidParams' gegevens
-    | code     | name                    | reason                  |
-    | required | gemeenteVanInschrijving | Parameter is verplicht. |
-
-Rule: Een gemeenteVanInschrijving is een string bestaande uit exact 4 cijfers
-
-  @fout-case
-  Abstract Scenario: <titel>
-    Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | <gemeenteVanInschrijving>      |
-    | fields                  | reisdocumentnummer             |
-    Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Een of meerdere parameters zijn niet correct.               |
-    | status   | 400                                                         |
-    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-    | code     | paramsValidation                                            |
-    | instance | /haalcentraal/api/reisdocumenten/reisdocumenten             |
-    En heeft het object de volgende 'invalidParams' gegevens
-    | code    | name                    | reason                                      |
-    | pattern | gemeenteVanInschrijving | Waarde voldoet niet aan patroon ^[0-9]{4}$. |
-
-    Voorbeelden:
-    | gemeenteVanInschrijving | titel                                                                          |
-    | 123                     | De opgegeven gemeenteVanInschrijving is een string met minder dan vier cijfers |
-    | 12345                   | De opgegeven gemeenteVanInschrijving is een string met meer dan vier cijfers   |
-    | 123O                    | De opgegeven gemeenteVanInschrijving is een string met een letter              |
-    | 12.4                    | De opgegeven gemeenteVanInschrijving bevat niet-cijfer                         |
 
 Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt
 

--- a/features/raadpleeg-met-reisdocumentnummer/gba/autorisatie-gba.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/gba/autorisatie-gba.feature
@@ -37,9 +37,6 @@ Functionaliteit: autorisatie voor het gebruik van de API RaadpleegMetReisdocumen
 
 
   Rule: Een gemeente als afnemer is geautoriseerd voor alle zoekvragen en alle gegevens voor haar eigen inwoners
-    Wanneer de afnemer parameter gemeenteVanInschrijving gebruikt 
-    en die is gelijk aan de waarde van gemeenteCode in de 'claim', 
-    dan wordt niet gekeken naar de autorisatie van de afnemer
 
     Scenario: Gemeente raadpleegt een reisdocument van een eigen inwoner. 'gemeentecode' claim komt overeen met 'gemeente van inschrijving' van houder
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens

--- a/features/raadpleeg-met-reisdocumentnummer/gba/autorisatie-gba.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/gba/autorisatie-gba.feature
@@ -9,11 +9,10 @@ Functionaliteit: autorisatie voor het gebruik van de API RaadpleegMetReisdocumen
   Deze feature beschrijft alleen de autorisatie van de afnemer door RvIG.
 
   Voorlopig wordt de reisdocumenten bevragen API alleen aangeboden aan gemeenten voor het raadplegen van reisdocumenten van eigen inwoners.
-  Gebruikers zijn daarom verplicht om de parameter gemeenteVanInschrijving te gebruiken en mogen dan alleen de gemeentecode van de eigen gemeente gebruiken.
 
   Autorisatie wordt verkregen met behulp van een OAuth 2 token. 
   In het verkregen token is de afnemerindicatie opgenomen die de afnemer uniek identificeert. Op basis van de afnemerindicatie kan de autorisatie worden opgezocht.
-  Wanneer de afnemer een gemeente is, is er ook een gemeentecode opgenomen in de OAuth token.
+  Wanneer de afnemer een gemeente is, is er ook een gemeentecode opgenomen in de OAuth token. Deze wordt gebruikt om te bepalen of een eigen inwoner houder is van het gevraagde reisdocument.
 
   Voor één afnemer kunnen er meerdere rijen zijn in de autorisatietabel, maar daarvan kan er maar één actueel zijn. Alleen de actuele mag worden gebruikt.
   Een autorisatie is actueel wanneer de Datum ingang (35.99.98) in het verleden ligt en Datum beëindiging tabelregel (35.99.99) leeg is of in de toekomst ligt.
@@ -42,37 +41,34 @@ Functionaliteit: autorisatie voor het gebruik van de API RaadpleegMetReisdocumen
     en die is gelijk aan de waarde van gemeenteCode in de 'claim', 
     dan wordt niet gekeken naar de autorisatie van de afnemer
 
-    Scenario: Gemeente zoekt reisdocumenten van een eigen inwoner door het opgeven van eigen gemeentecode als gemeenteVanInschrijving
+    Scenario: Gemeente raadpleegt een reisdocument van een eigen inwoner. 'gemeentecode' claim komt overeen met 'gemeente van inschrijving' van houder
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
       | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
       | 10120                           | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
-      | gemeenteCode | 0800   |
+      | afnemerID | gemeenteCode |
+      | 000008    | 0800         |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                                                                     |
-      | type                    | RaadpleegMetReisdocumentnummer                                             |
-      | reisdocumentnummer      | NE3663258                                                                  |
-      | gemeenteVanInschrijving | 0800                                                                       |
-      | fields                  | reisdocumentnummer,soort,datumEindeGeldigheid,inhoudingOfVermissing,houder |
+      | naam               | waarde                                                                     |
+      | type               | RaadpleegMetReisdocumentnummer                                             |
+      | reisdocumentnummer | NE3663258                                                                  |
+      | fields             | reisdocumentnummer,soort,datumEindeGeldigheid,inhoudingOfVermissing,houder |
       Dan heeft de response 1 reisdocument
 
     @fout-case
-    Scenario: Gemeente zoekt een reisdocument voor een inwoner van een andere gemeente met parameter gemeenteVanInschrijving
+    Scenario: Gemeente raadpleegt een reisdocument van een inwoner van een andere gemeente
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
       | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
       | 10120                           | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
       | naam         | waarde |
       | afnemerID    | 000008 |
-      | gemeenteCode | 0800   |
+      | gemeenteCode | 0599   |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0599                           |
-      | fields                  | reisdocumentnummer             |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | reisdocumentnummer             |
       Dan heeft de response een object met de volgende gegevens
       | naam     | waarde                                                                      |
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                 |
@@ -81,52 +77,3 @@ Functionaliteit: autorisatie voor het gebruik van de API RaadpleegMetReisdocumen
       | detail   | Je mag alleen reisdocumenten van inwoners uit de eigen gemeente raadplegen. |
       | code     | unauthorized                                                                |
       | instance | /haalcentraal/api/reisdocumenten/reisdocumenten                             |
-
-    Scenario: Gemeente zoekt een reisdocument voor een inwoner van een andere gemeente door het opgeven van eigen gemeentecode als gemeenteVanInschrijving
-      Gegeven de persoon met burgerservicenummer '000000024' heeft een 'reisdocument' met de volgende gegevens
-      | naam                        | waarde    |
-      | soort reisdocument (35.10)  | NI        |
-      | nummer reisdocument (35.20) | ID123NL45 |
-      En de persoon heeft de volgende 'verblijfplaats' gegevens
-      | gemeente van inschrijving (09.10) |
-      | 0530                              |
-      En de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
-      | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
-      | 10120                           | N                        | 20201128                |
-      En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
-      | gemeenteCode | 0800   |
-      Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | ID123NL45                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | reisdocumentnummer             |
-      Dan heeft de response 0 reisdocumenten
-
-    @fout-case
-    Scenario: Gebruik van de parameter gemeenteVanInschrijving is verplicht
-      Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
-      | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
-      | 10120                           | N                        | 20201128                |
-      En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
-      | gemeenteCode | 0800   |
-      Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam               | waarde                         |
-      | type               | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer | NE3663258                      |
-      | fields             | reisdocumentnummer             |
-      Dan heeft de response een object met de volgende gegevens
-      | naam     | waarde                                                      |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-      | title    | Een of meerdere parameters zijn niet correct.               |
-      | status   | 400                                                         |
-      | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-      | code     | paramsValidation                                            |
-      | instance | /haalcentraal/api/reisdocumenten/reisdocumenten             |
-      En heeft het object de volgende 'invalidParams' gegevens
-      | code     | name                    | reason                  |
-      | required | gemeenteVanInschrijving | Parameter is verplicht. |

--- a/features/raadpleeg-met-reisdocumentnummer/gba/fields-gba.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/gba/fields-gba.feature
@@ -17,22 +17,20 @@ Functionaliteit: Reisdocument velden vragen met fields
 
   Scenario: 'nummer reisdocument (35.20)' wordt gevraagd met field pad 'reisdocumentnummer'
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer             |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | reisdocumentnummer             |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde    |
     | reisdocumentnummer | NE3663258 |
 
   Abstract Scenario: 'soort reisdocument (35.10)' wordt gevraagd met field pad '<field>'
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | <field>                        |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | <field>                        |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde             |
     | soort.code         | PN                 |
@@ -46,11 +44,10 @@ Functionaliteit: Reisdocument velden vragen met fields
 
   Abstract Scenario: 'datum einde geldigheid reisdocument (35.50)' wordt gevraagd met field pad '<field>'
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | <field>                        |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | <field>                        |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam                 | waarde   |
     | datumEindeGeldigheid | 20240506 |
@@ -67,11 +64,10 @@ Functionaliteit: Reisdocument velden vragen met fields
 
   Abstract Scenario: 'datum inhouding dan wel vermissing Nederlands reisdocument (35.60)' wordt gevraagd met field pad 'inhoudingOfVermissing.<field>'
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | inhoudingOfVermissing.<field>  |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | inhoudingOfVermissing.<field>  |
     Dan heeft de response een 'reisdocument' met de volgende 'inhoudingOfVermissing' gegevens
     | naam  | waarde   |
     | datum | 20230405 |
@@ -88,11 +84,10 @@ Functionaliteit: Reisdocument velden vragen met fields
 
   Abstract Scenario: 'aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70)' wordt gevraagd met field pad 'inhoudingOfVermissing.<field>'
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | inhoudingOfVermissing.<field>  |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | inhoudingOfVermissing.<field>  |
     Dan heeft de response een 'reisdocument' met de volgende 'inhoudingOfVermissing' gegevens
     | naam                    | waarde                   |
     | aanduiding.code         | I                        |
@@ -106,11 +101,10 @@ Functionaliteit: Reisdocument velden vragen met fields
 
   Scenario: 'burgerservicenummer' van houder wordt gevraagd met field pad 'houder.burgerservicenummer'
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | houder.burgerservicenummer     |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | houder.burgerservicenummer     |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                | waarde    |
     | burgerservicenummer | 000000152 |

--- a/features/raadpleeg-met-reisdocumentnummer/gba/fout-cases-gba.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/gba/fout-cases-gba.feature
@@ -8,10 +8,9 @@ Rule: De reisdocumentnummer parameter is een verplichte parameter
   @fout-case
   Scenario: De reisdocumentnummer parameter is niet opgegeven
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer             |
+    | naam   | waarde                         |
+    | type   | RaadpleegMetReisdocumentnummer |
+    | fields | reisdocumentnummer             |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -29,11 +28,10 @@ Rule: De reisdocumentnummer parameter bevat een lijst met minimaal één reisdoc
   @fout-case
   Abstract Scenario: De reisdocumentnummer parameter bevat een lege lijst
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      |                                |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer             |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer |                                |
+    | fields             | reisdocumentnummer             |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -51,11 +49,10 @@ Rule: Een reisdocumentnummer is een string bestaande uit exact 9 cijfers en hoof
   @fout-case
   Abstract Scenario: <titel>
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | <reisdocumentnummers>          |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer             |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | <reisdocumentnummers>          |
+    | fields             | reisdocumentnummer             |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -80,11 +77,10 @@ Rule: De reisdocumentnummer parameter bevat een lijst van maximaal 1 reisdocumen
   @fout-case
   Scenario: De reisdocumentnummer parameter bevat meer dan 1 reisdocumentnummer
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | AB1234567,BC8901234            |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer             |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | AB1234567,BC8901234            |
+    | fields             | reisdocumentnummer             |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -96,53 +92,3 @@ Rule: De reisdocumentnummer parameter bevat een lijst van maximaal 1 reisdocumen
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name               | reason                        |
     | maxItems | reisdocumentnummer | Array bevat meer dan 1 items. |
-
-Rule: De gemeenteVanInschrijving parameter is een verplichte parameter
-
-  @fout-case
-  Scenario: De gemeenteVanInschrijving parameter is niet opgegeven
-    Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam               | waarde                         |
-    | type               | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer | NE3663258                      |
-    | fields             | reisdocumentnummer             |
-    Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Een of meerdere parameters zijn niet correct.               |
-    | status   | 400                                                         |
-    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-    | code     | paramsValidation                                            |
-    | instance | /haalcentraal/api/reisdocumenten/reisdocumenten             |
-    En heeft het object de volgende 'invalidParams' gegevens
-    | code     | name                    | reason                  |
-    | required | gemeenteVanInschrijving | Parameter is verplicht. |
-
-Rule: Een gemeenteVanInschrijving is een string bestaande uit exact 4 cijfers
-
-  @fout-case
-  Abstract Scenario: <titel>
-    Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | <gemeenteVanInschrijving>      |
-    | fields                  | reisdocumentnummer             |
-    Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Een of meerdere parameters zijn niet correct.               |
-    | status   | 400                                                         |
-    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-    | code     | paramsValidation                                            |
-    | instance | /haalcentraal/api/reisdocumenten/reisdocumenten             |
-    En heeft het object de volgende 'invalidParams' gegevens
-    | code    | name                    | reason                                      |
-    | pattern | gemeenteVanInschrijving | Waarde voldoet niet aan patroon ^[0-9]{4}$. |
-
-    Voorbeelden:
-    | gemeenteVanInschrijving | titel                                                                          |
-    | 123                     | De opgegeven gemeenteVanInschrijving is een string met minder dan vier cijfers |
-    | 12345                   | De opgegeven gemeenteVanInschrijving is een string met meer dan vier cijfers   |
-    | 123O                    | De opgegeven gemeenteVanInschrijving is een string met een letter              |
-    | 12.4                    | De opgegeven gemeenteVanInschrijving bevat niet-cijfer                         |

--- a/features/raadpleeg-met-reisdocumentnummer/gba/in-onderzoek-gba.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/gba/in-onderzoek-gba.feature
@@ -17,11 +17,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                                        |
-    | type                    | RaadpleegMetReisdocumentnummer                |
-    | reisdocumentnummer      | NE3663258                                     |
-    | gemeenteVanInschrijving | 0800                                          |
-    | fields                  | reisdocumentnummer,soort,datumEindeGeldigheid |
+    | naam               | waarde                                        |
+    | type               | RaadpleegMetReisdocumentnummer                |
+    | reisdocumentnummer | NE3663258                                     |
+    | fields             | reisdocumentnummer,soort,datumEindeGeldigheid |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam                                      | waarde                    |
     | reisdocumentnummer                        | NE3663258                 |
@@ -57,11 +56,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | houder                         |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | houder                         |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                                      | waarde                    |
     | burgerservicenummer                       | 000000152                 |
@@ -90,11 +88,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | houder.burgerservicenummer     |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | houder.burgerservicenummer     |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                                      | waarde                    |
     | burgerservicenummer                       | 000000152                 |
@@ -121,11 +118,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | houder                         |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | houder                         |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                | waarde    |
     | burgerservicenummer | 000000152 |
@@ -151,11 +147,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer,soort       |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | reisdocumentnummer,soort       |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde             |
     | reisdocumentnummer | NE3663258          |

--- a/features/raadpleeg-met-reisdocumentnummer/gba/inhouding-of-vermissing-gba.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/gba/inhouding-of-vermissing-gba.feature
@@ -13,11 +13,10 @@ Functionaliteit: Aanduiding inhouding/vermissing van reisdocument vragen geeft o
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                           |
-      | type                    | RaadpleegMetReisdocumentnummer   |
-      | reisdocumentnummer      | NE3663258                        |
-      | gemeenteVanInschrijving | 0800                             |
-      | fields                  | inhoudingOfVermissing.aanduiding |
+      | naam               | waarde                           |
+      | type               | RaadpleegMetReisdocumentnummer   |
+      | reisdocumentnummer | NE3663258                        |
+      | fields             | inhoudingOfVermissing.aanduiding |
       Dan heeft de response een 'reisdocument' met de volgende 'inhoudingOfVermissing' gegevens
       | naam                    | waarde         |
       | aanduiding.code         | <aanduiding>   |

--- a/features/raadpleeg-met-reisdocumentnummer/gba/opschorting-bijhouding-gba.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/gba/opschorting-bijhouding-gba.feature
@@ -17,11 +17,10 @@ Functionaliteit: RaadpleegMetReisdocumentnummer van persoonslijst met opschortin
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | <fields>                       |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | <fields>                       |
       Dan heeft de response 0 reisdocumenten
 
       Voorbeelden:
@@ -46,11 +45,10 @@ Functionaliteit: RaadpleegMetReisdocumentnummer van persoonslijst met opschortin
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | houder.burgerservicenummer     |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | houder.burgerservicenummer     |
       Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
       | naam                | waarde    |
       | burgerservicenummer | 000000048 |
@@ -70,11 +68,10 @@ Rule: opschortingBijhouding wordt automatisch geleverd indien van toepassing
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | houder.burgerservicenummer     |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | houder.burgerservicenummer     |
       Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
       | naam                                     | waarde         |
       | burgerservicenummer                      | 000000024      |
@@ -106,11 +103,10 @@ Rule: opschortingBijhouding wordt automatisch geleverd indien van toepassing
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | <fields>                       |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | <fields>                       |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam     | waarde     |
       | <veld 1> | <waarde 1> |

--- a/features/raadpleeg-met-reisdocumentnummer/gba/protocollering-gba.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/gba/protocollering-gba.feature
@@ -33,11 +33,10 @@ Functionaliteit: Protocolleren van RaadpleegMetReisdocumentnummer
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | inhoudingOfVermissing,houder   |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | inhoudingOfVermissing,houder   |
       Dan heeft de persoon met burgerservicenummer '000000012' de volgende 'protocollering' gegevens
       | request_zoek_rubrieken |
       | 080910, 123520         |
@@ -54,11 +53,10 @@ Functionaliteit: Protocolleren van RaadpleegMetReisdocumentnummer
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | <fields>                       |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | <fields>                       |
       Dan heeft de persoon met burgerservicenummer '000000012' de volgende 'protocollering' gegevens
       | request_gevraagde_rubrieken |
       | <gevraagde rubrieken>       |

--- a/features/raadpleeg-met-reisdocumentnummer/gba/protocollering-gba.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/gba/protocollering-gba.feature
@@ -39,7 +39,7 @@ Functionaliteit: Protocolleren van RaadpleegMetReisdocumentnummer
       | fields             | inhoudingOfVermissing,houder   |
       Dan heeft de persoon met burgerservicenummer '000000012' de volgende 'protocollering' gegevens
       | request_zoek_rubrieken |
-      | 080910, 123520         |
+      | 123520                 |
 
   Rule: Gevraagde velden in fields worden vertaald naar rubrieknummers, oplopend gesorteerd en gescheiden door komma en spatie
 

--- a/features/raadpleeg-met-reisdocumentnummer/gba/soort-reisdocument-gba.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/gba/soort-reisdocument-gba.feature
@@ -14,11 +14,10 @@ Functionaliteit: Soort reisdocument
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | soort                          |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | soort                          |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam               | waarde         |
       | soort.code         | <code>         |

--- a/features/raadpleeg-met-reisdocumentnummer/geheimhouding/gba/overzicht-gba.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/geheimhouding/gba/overzicht-gba.feature
@@ -8,10 +8,10 @@ Functionaliteit: gba geheimhouding leveren bij RaadpleegMetReisdocumentnummer
 
   Achtergrond:
       Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-      | naam                                            | waarde    |
-      | soort reisdocument (35.10)                      | PN        |
-      | nummer reisdocument (35.20)                     | NE3663258 |
-      | datum einde geldigheid reisdocument (35.50)     | 20330506  |
+      | naam                                        | waarde    |
+      | soort reisdocument (35.10)                  | PN        |
+      | nummer reisdocument (35.20)                 | NE3663258 |
+      | datum einde geldigheid reisdocument (35.50) | 20330506  |
       En de persoon heeft de volgende 'verblijfplaats' gegevens
       | gemeente van inschrijving (09.10) |
       | 0800                              |
@@ -24,11 +24,10 @@ Functionaliteit: gba geheimhouding leveren bij RaadpleegMetReisdocumentnummer
       | naam                     | waarde |
       | indicatie geheim (70.10) | 0      |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | reisdocumentnummer             |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | reisdocumentnummer             |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam               | waarde    |
       | reisdocumentnummer | NE3663258 |
@@ -41,11 +40,10 @@ Functionaliteit: gba geheimhouding leveren bij RaadpleegMetReisdocumentnummer
       | naam                     | waarde   |
       | indicatie geheim (70.10) | <waarde> |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | reisdocumentnummer             |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | reisdocumentnummer             |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam                                 | waarde    |
       | reisdocumentnummer                   | NE3663258 |
@@ -66,11 +64,10 @@ Functionaliteit: gba geheimhouding leveren bij RaadpleegMetReisdocumentnummer
       | naam                     | waarde |
       | indicatie geheim (70.10) | 7      |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | <fields>                       |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | <fields>                       |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam                                 | waarde     |
       | <veld 1>                             | <waarde 1> |
@@ -93,11 +90,10 @@ Functionaliteit: gba geheimhouding leveren bij RaadpleegMetReisdocumentnummer
     @fout-case
     Abstract Scenario: veld geheimhoudingPersoonsgegevens mag niet worden gevraagd, omdat het automatisch wordt geleverd
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | <fields>                       |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | <fields>                       |
       Dan heeft de response een object met de volgende gegevens
       | naam     | waarde                                                      |
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -111,7 +107,7 @@ Functionaliteit: gba geheimhouding leveren bij RaadpleegMetReisdocumentnummer
       | fields | fields[<index>] | Parameter bevat een niet toegestane veldnaam. |
 
       Voorbeelden:
-      | fields                                                                                   | index |
-      | houder.geheimhoudingPersoonsgegevens                                                     | 0     |
-      | reisdocumentnummer,houder.geheimhoudingPersoonsgegevens,houder.burgerservicenummer       | 1     |
-      | soort,inhoudingOfVermissing.datum,houder.geheimhoudingPersoonsgegevens                   | 2     |
+      | fields                                                                             | index |
+      | houder.geheimhoudingPersoonsgegevens                                               | 0     |
+      | reisdocumentnummer,houder.geheimhoudingPersoonsgegevens,houder.burgerservicenummer | 1     |
+      | soort,inhoudingOfVermissing.datum,houder.geheimhoudingPersoonsgegevens             | 2     |

--- a/features/raadpleeg-met-reisdocumentnummer/geheimhouding/overzicht.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/geheimhouding/overzicht.feature
@@ -7,10 +7,10 @@ Functionaliteit: geheimhouding leveren bij RaadpleegMetReisdocumentnummer
 
   Achtergrond:
       Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-      | naam                                            | waarde    |
-      | soort reisdocument (35.10)                      | PN        |
-      | nummer reisdocument (35.20)                     | NE3663258 |
-      | datum einde geldigheid reisdocument (35.50)     | 20330506  |
+      | naam                                        | waarde    |
+      | soort reisdocument (35.10)                  | PN        |
+      | nummer reisdocument (35.20)                 | NE3663258 |
+      | datum einde geldigheid reisdocument (35.50) | 20330506  |
       En de persoon heeft de volgende 'verblijfplaats' gegevens
       | gemeente van inschrijving (09.10) |
       | 0800                              |
@@ -23,11 +23,10 @@ Functionaliteit: geheimhouding leveren bij RaadpleegMetReisdocumentnummer
       | naam                     | waarde |
       | indicatie geheim (70.10) | 0      |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | reisdocumentnummer             |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | reisdocumentnummer             |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam               | waarde    |
       | reisdocumentnummer | NE3663258 |
@@ -40,11 +39,10 @@ Functionaliteit: geheimhouding leveren bij RaadpleegMetReisdocumentnummer
       | naam                     | waarde   |
       | indicatie geheim (70.10) | <waarde> |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | reisdocumentnummer             |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | reisdocumentnummer             |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam                                 | waarde    |
       | reisdocumentnummer                   | NE3663258 |
@@ -65,11 +63,10 @@ Functionaliteit: geheimhouding leveren bij RaadpleegMetReisdocumentnummer
       | naam                     | waarde |
       | indicatie geheim (70.10) | 7      |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | <fields>                       |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | <fields>                       |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam                                 | waarde     |
       | <veld 1>                             | <waarde 1> |
@@ -94,11 +91,10 @@ Functionaliteit: geheimhouding leveren bij RaadpleegMetReisdocumentnummer
     @fout-case
     Abstract Scenario: veld geheimhoudingPersoonsgegevens mag niet worden gevraagd, omdat het automatisch wordt geleverd
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | <fields>                       |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | <fields>                       |
       Dan heeft de response een object met de volgende gegevens
       | naam     | waarde                                                      |
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -112,7 +108,7 @@ Functionaliteit: geheimhouding leveren bij RaadpleegMetReisdocumentnummer
       | fields | fields[<index>] | Parameter bevat een niet toegestane veldnaam. |
 
       Voorbeelden:
-      | fields                                                                                   | index |
-      | houder.geheimhoudingPersoonsgegevens                                                     | 0     |
-      | reisdocumentnummer,houder.geheimhoudingPersoonsgegevens,houder.burgerservicenummer       | 1     |
-      | soort,inhoudingOfVermissing.datum,houder.geheimhoudingPersoonsgegevens                   | 2     |
+      | fields                                                                             | index |
+      | houder.geheimhoudingPersoonsgegevens                                               | 0     |
+      | reisdocumentnummer,houder.geheimhoudingPersoonsgegevens,houder.burgerservicenummer | 1     |
+      | soort,inhoudingOfVermissing.datum,houder.geheimhoudingPersoonsgegevens             | 2     |

--- a/features/raadpleeg-met-reisdocumentnummer/in-onderzoek.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/in-onderzoek.feature
@@ -16,11 +16,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                                        |
-    | type                    | RaadpleegMetReisdocumentnummer                |
-    | reisdocumentnummer      | NE3663258                                     |
-    | gemeenteVanInschrijving | 0800                                          |
-    | fields                  | reisdocumentnummer,soort,datumEindeGeldigheid |
+    | naam               | waarde                                        |
+    | type               | RaadpleegMetReisdocumentnummer                |
+    | reisdocumentnummer | NE3663258                                     |
+    | fields             | reisdocumentnummer,soort,datumEindeGeldigheid |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam                                         | waarde                      |
     | reisdocumentnummer                           | NE3663258                   |
@@ -58,11 +57,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                                        |
-    | type                    | RaadpleegMetReisdocumentnummer                |
-    | reisdocumentnummer      | NE3663258                                     |
-    | gemeenteVanInschrijving | 0800                                          |
-    | fields                  | reisdocumentnummer,soort,datumEindeGeldigheid |
+    | naam               | waarde                                        |
+    | type               | RaadpleegMetReisdocumentnummer                |
+    | reisdocumentnummer | NE3663258                                     |
+    | fields             | reisdocumentnummer,soort,datumEindeGeldigheid |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam                             | waarde             |
     | reisdocumentnummer               | NE3663258          |
@@ -93,11 +91,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | inhoudingOfVermissing          |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | inhoudingOfVermissing          |
     Dan heeft de response een 'reisdocument' met de volgende 'inhoudingOfVermissing' gegevens
     | naam                                         | waarde                               |
     | datum.type                                   | Datum                                |
@@ -132,11 +129,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | inhoudingOfVermissing          |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | inhoudingOfVermissing          |
     Dan heeft de response een 'reisdocument' met de volgende 'inhoudingOfVermissing' gegevens
     | naam                    | waarde                   |
     | datum.type              | Datum                    |
@@ -167,11 +163,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | houder                         |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | houder                         |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                                         | waarde          |
     | burgerservicenummer                          | 000000152       |
@@ -200,11 +195,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | houder                         |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | houder                         |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                | waarde    |
     | burgerservicenummer | 000000152 |
@@ -226,11 +220,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | houder                         |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | houder                         |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                | waarde    |
     | burgerservicenummer | 000000152 |

--- a/features/raadpleeg-met-reisdocumentnummer/inhouding-of-vermissing.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/inhouding-of-vermissing.feature
@@ -13,11 +13,10 @@ Functionaliteit: Aanduiding inhouding/vermissing van reisdocument vragen geeft o
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                           |
-      | type                    | RaadpleegMetReisdocumentnummer   |
-      | reisdocumentnummer      | NE3663258                        |
-      | gemeenteVanInschrijving | 0800                             |
-      | fields                  | inhoudingOfVermissing.aanduiding |
+      | naam               | waarde                           |
+      | type               | RaadpleegMetReisdocumentnummer   |
+      | reisdocumentnummer | NE3663258                        |
+      | fields             | inhoudingOfVermissing.aanduiding |
       Dan heeft de response een 'reisdocument' met de volgende 'inhoudingOfVermissing' gegevens
       | naam                    | waarde         |
       | aanduiding.code         | <aanduiding>   |

--- a/features/raadpleeg-met-reisdocumentnummer/overzicht.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/overzicht.feature
@@ -2,7 +2,7 @@
 
 Functionaliteit: Raadpleeg met reisdocumentnummer
 
-Rule: voor het raadplegen van een reisdocument moet het reisdocumentnummer en de gemeenteVanInschrijving worden opgegeven
+Rule: voor het raadplegen van een reisdocument moet het reisdocumentnummer worden opgegeven
 
   Scenario: Raadpleeg een reisdocument
     Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
@@ -14,11 +14,10 @@ Rule: voor het raadplegen van een reisdocument moet het reisdocumentnummer en de
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer,houder      |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | reisdocumentnummer,houder      |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde    |
     | reisdocumentnummer | NE3663258 |
@@ -36,11 +35,10 @@ Rule: voor het raadplegen van een reisdocument moet het reisdocumentnummer en de
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663259                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer,houder      |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663259                      |
+    | fields             | reisdocumentnummer,houder      |
     Dan heeft de response 0 reisdocumenten
 
 Rule: als een gevraagde veld in onderzoek is, dan wordt het bijbehorend inOnderzoek veld en datumIngangOnderzoek ook geleverd
@@ -57,11 +55,10 @@ Rule: als een gevraagde veld in onderzoek is, dan wordt het bijbehorend inOnderz
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer,soort       |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | reisdocumentnummer,soort       |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam                                         | waarde             |
     | reisdocumentnummer                           | NE3663258          |
@@ -84,12 +81,10 @@ Rule: als een gevraagde veld in onderzoek is, dan wordt het bijbehorend inOnderz
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                         |
-    | type                    | RaadpleegMetReisdocumentnummer |
-    | reisdocumentnummer      | NE3663258                      |
-    | gemeenteVanInschrijving | 0800                           |
-    | fields                  | reisdocumentnummer             |
+    | naam               | waarde                         |
+    | type               | RaadpleegMetReisdocumentnummer |
+    | reisdocumentnummer | NE3663258                      |
+    | fields             | reisdocumentnummer             |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde    |
     | reisdocumentnummer | NE3663258 |
-

--- a/features/raadpleeg-met-reisdocumentnummer/soort-reisdocument.feature
+++ b/features/raadpleeg-met-reisdocumentnummer/soort-reisdocument.feature
@@ -13,11 +13,10 @@ Functionaliteit: Soort reisdocument
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | soort                          |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | soort                          |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam               | waarde         |
       | soort.code         | <code>         |
@@ -40,10 +39,9 @@ Functionaliteit: Soort reisdocument
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | NE3663258                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | soort                          |
+      | naam               | waarde                         |
+      | type               | RaadpleegMetReisdocumentnummer |
+      | reisdocumentnummer | NE3663258                      |
+      | fields             | soort                          |
       Dan heeft de response een 'reisdocument' zonder gegevens
     

--- a/features/zoek-fout-cases.feature
+++ b/features/zoek-fout-cases.feature
@@ -65,12 +65,11 @@ Rule: Voor de response body wordt als content type en charset respectievelijk al
   @fout-case
   Abstract Scenario: 'application/xml' is opgegeven als Accept content type
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde             |
-    | type                    | <zoek type>        |
-    | <naam parameter>        | <waarde parameter> |
-    | gemeenteVanInschrijving | 0800               |
-    | fields                  | reisdocumentnummer |
-    | header: Accept          | application/xml    |
+    | naam             | waarde             |
+    | type             | <zoek type>        |
+    | <naam parameter> | <waarde parameter> |
+    | fields           | reisdocumentnummer |
+    | header: Accept   | application/xml    |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6 |
@@ -87,12 +86,11 @@ Rule: Voor de response body wordt als content type en charset respectievelijk al
 
   Abstract Scenario: '<accept media type>' wordt opgegeven als Accept content type
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000024                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | houder.burgerservicenummer |
-    | header: Accept          | <accept media type>        |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000024                  |
+    | fields              | houder.burgerservicenummer |
+    | header: Accept      | <accept media type>        |
     Dan heeft de response 0 reisdocumenten
 
     Voorbeelden:
@@ -111,11 +109,10 @@ Rule: Voor de response body is application/json de default Accept waarde en is u
 
   Abstract Scenario: Er is geen Accept header met waarde opgegeven
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | <zoek type>                |
-    | <naam parameter>        | <waarde parameter>         |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | houder.burgerservicenummer |
+    | naam             | waarde                     |
+    | type             | <zoek type>                |
+    | <naam parameter> | <waarde parameter>         |
+    | fields           | houder.burgerservicenummer |
     Dan heeft de response 0 reisdocumenten
 
     Voorbeelden:
@@ -125,12 +122,11 @@ Rule: Voor de response body is application/json de default Accept waarde en is u
 
   Abstract Scenario: Er is een lege waarde opgegeven voor de Accept header
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | <zoek type>                |
-    | <naam parameter>        | <waarde parameter>         |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | houder.burgerservicenummer |
-    | header: Accept          |                            |
+    | naam             | waarde                     |
+    | type             | <zoek type>                |
+    | <naam parameter> | <waarde parameter>         |
+    | fields           | houder.burgerservicenummer |
+    | header: Accept   |                            |
     Dan heeft de response 0 reisdocumenten
 
     Voorbeelden:
@@ -143,12 +139,11 @@ Rule: Voor de request body wordt als content type en charset respectievelijk all
   @fout-case
   Abstract Scenario: '<media type>' is opgegeven als Content-Type waarde
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde             |
-    | type                    | <zoek type>        |
-    | <naam parameter>        | <waarde parameter> |
-    | gemeenteVanInschrijving | 0800               |
-    | fields                  | reisdocumentnummer |
-    | header: Content-Type    | <media type>       |
+    | naam                 | waarde             |
+    | type                 | <zoek type>        |
+    | <naam parameter>     | <waarde parameter> |
+    | fields               | reisdocumentnummer |
+    | header: Content-Type | <media type>       |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                       |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13 |
@@ -189,11 +184,10 @@ Rule: Voor de request body is application/json de default Content-Type waarde en
 
   Abstract Scenario: Er is geen Content-Type header met waarde opgegeven
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | <zoek type>                |
-    | <naam parameter>        | <waarde parameter>         |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | houder.burgerservicenummer |
+    | naam             | waarde                     |
+    | type             | <zoek type>                |
+    | <naam parameter> | <waarde parameter>         |
+    | fields           | houder.burgerservicenummer |
     Dan heeft de response 0 reisdocumenten
 
     Voorbeelden:
@@ -203,12 +197,11 @@ Rule: Voor de request body is application/json de default Content-Type waarde en
 
   Abstract Scenario: Er is een lege waarde opgegeven voor de Content-Type header
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | <zoek type>                |
-    | <naam parameter>        | <waarde parameter>         |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | houder.burgerservicenummer |
-    | header: Content-Type    |                            |
+    | naam                 | waarde                     |
+    | type                 | <zoek type>                |
+    | <naam parameter>     | <waarde parameter>         |
+    | fields               | houder.burgerservicenummer |
+    | header: Content-Type |                            |
     Dan heeft de response 0 reisdocumenten
 
     Voorbeelden:
@@ -236,5 +229,5 @@ Rule: Om privacy en security redenen moet een bevraging van reisdocumenten worde
     | DELETE       |
     # | CONNECT      | een CONNECT aanroep wordt niet gebruikt om te bevragen
     # | HEAD         | een HEAD response bevat geen body
-    | OPTIONS      |
-    | TRACE        |
+    | OPTIONS |
+    | TRACE   |

--- a/features/zoek-fout-cases.feature
+++ b/features/zoek-fout-cases.feature
@@ -167,7 +167,6 @@ Rule: Voor de request body wordt als content type en charset respectievelijk all
     | naam                    | waarde                     |
     | type                    | <zoek type>                |
     | <naam parameter>        | <waarde parameter>         |
-    | gemeenteVanInschrijving | 0800                       |
     | fields                  | houder.burgerservicenummer |
     | header: Content-Type    | <media type>               |
     Dan heeft de response 0 reisdocumenten
@@ -227,7 +226,7 @@ Rule: Om privacy en security redenen moet een bevraging van reisdocumenten worde
     | PUT          |
     | PATCH        |
     | DELETE       |
-    # | CONNECT      | een CONNECT aanroep wordt niet gebruikt om te bevragen
-    # | HEAD         | een HEAD response bevat geen body
-    | OPTIONS |
-    | TRACE   |
+  # | CONNECT      | een CONNECT aanroep wordt niet gebruikt om te bevragen
+  # | HEAD         | een HEAD response bevat geen body
+    | OPTIONS      |
+    | TRACE        |

--- a/features/zoek-met-burgerservicenummer/fields.feature
+++ b/features/zoek-met-burgerservicenummer/fields.feature
@@ -4,32 +4,30 @@ Functionaliteit: Reisdocument velden zoek op burgerservicenummer met fields
 
   Achtergrond:
     Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-    | naam                                                                    | waarde    |
-    | soort reisdocument (35.10)                                              | PN        |
-    | nummer reisdocument (35.20)                                             | NE3663258 |
-    | datum einde geldigheid reisdocument (35.50)                             | 20240506  |
+    | naam                                        | waarde    |
+    | soort reisdocument (35.10)                  | PN        |
+    | nummer reisdocument (35.20)                 | NE3663258 |
+    | datum einde geldigheid reisdocument (35.50) | 20240506  |
     En de persoon heeft de volgende 'verblijfplaats' gegevens
     | gemeente van inschrijving (09.10) |
     | 0800                              |
 
   Scenario: 'nummer reisdocument (35.20)' wordt gevraagd met field pad 'reisdocumentnummer'
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer         |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | reisdocumentnummer         |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde    |
     | reisdocumentnummer | NE3663258 |
 
   Abstract Scenario: 'soort reisdocument (35.10)' wordt gevraagd met field pad '<field>'
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | <field>                    |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | <field>                    |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde             |
     | soort.code         | PN                 |
@@ -43,11 +41,10 @@ Functionaliteit: Reisdocument velden zoek op burgerservicenummer met fields
 
   Abstract Scenario: 'datum einde geldigheid reisdocument (35.50)' wordt gevraagd met field pad '<field>'
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | <field>                    |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | <field>                    |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam                             | waarde     |
     | datumEindeGeldigheid.type        | Datum      |
@@ -66,11 +63,10 @@ Functionaliteit: Reisdocument velden zoek op burgerservicenummer met fields
 
   Scenario: 'burgerservicenummer' van houder wordt gevraagd met field pad 'houder.burgerservicenummer'
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | houder.burgerservicenummer |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | houder.burgerservicenummer |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                | waarde    |
     | burgerservicenummer | 000000152 |

--- a/features/zoek-met-burgerservicenummer/fout-cases.feature
+++ b/features/zoek-met-burgerservicenummer/fout-cases.feature
@@ -7,10 +7,9 @@ Rule: De burgerservicenummer parameter is een verplichte parameter
   @fout-case
   Scenario: De burgerservicenummer parameter is niet opgegeven
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer         |
+    | naam   | waarde                     |
+    | type   | ZoekMetBurgerservicenummer |
+    | fields | reisdocumentnummer         |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -29,11 +28,10 @@ Rule: Een burgerservicenummer is een string bestaande uit exact 9 cijfers
   @fout-case
   Abstract Scenario: <titel>
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | <burgerservicenummer>      |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer         |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | <burgerservicenummer>      |
+    | fields              | reisdocumentnummer         |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -52,68 +50,16 @@ Rule: Een burgerservicenummer is een string bestaande uit exact 9 cijfers
     | 1234567890          | De opgegeven burgerservicenummer is een string met meer dan negen cijfers   |
     | 12345678X           | De opgegeven burgerservicenummer is een string met een letter               |
 
-
-Rule: De gemeenteVanInschrijving parameter is een verplichte parameter
-
-  @fout-case
-  Scenario: De gemeenteVanInschrijving parameter is niet opgegeven
-    Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                | waarde                     |
-    | type                | ZoekMetBurgerservicenummer |
-    | burgerservicenummer | 123456789                  |
-    | fields              | reisdocumentnummer         |
-    Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Een of meerdere parameters zijn niet correct.               |
-    | status   | 400                                                         |
-    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-    | code     | paramsValidation                                            |
-    | instance | /haalcentraal/api/reisdocumenten/reisdocumenten             |
-    En heeft het object de volgende 'invalidParams' gegevens
-    | code     | name                    | reason                  |
-    | required | gemeenteVanInschrijving | Parameter is verplicht. |
-
-Rule: Een gemeenteVanInschrijving is een string bestaande uit exact 4 cijfers
-
-  @fout-case
-  Abstract Scenario: <titel>
-    Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 123456789                  |
-    | gemeenteVanInschrijving | <gemeenteVanInschrijving>  |
-    | fields                  | reisdocumentnummer         |
-    Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Een of meerdere parameters zijn niet correct.               |
-    | status   | 400                                                         |
-    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-    | code     | paramsValidation                                            |
-    | instance | /haalcentraal/api/reisdocumenten/reisdocumenten             |
-    En heeft het object de volgende 'invalidParams' gegevens
-    | code    | name                    | reason                                      |
-    | pattern | gemeenteVanInschrijving | Waarde voldoet niet aan patroon ^[0-9]{4}$. |
-
-    Voorbeelden:
-    | gemeenteVanInschrijving | titel                                                                          |
-    | 123                     | De opgegeven gemeenteVanInschrijving is een string met minder dan vier cijfers |
-    | 12345                   | De opgegeven gemeenteVanInschrijving is een string met meer dan vier cijfers   |
-    | 123X                    | De opgegeven gemeenteVanInschrijving is een string met een letter              |
-    | 12.4                    | De opgegeven gemeenteVanInschrijving bevat niet-cijfer                         |
-
 Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt
 
   @fout-case
   Abstract Scenario: <titel>
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 123456789                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | <parameter>             | <waarde>                   |
-    | fields                  | reisdocumentnummer         |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 123456789                  |
+    | <parameter>         | <waarde>                   |
+    | fields              | reisdocumentnummer         |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |

--- a/features/zoek-met-burgerservicenummer/gba/actuele-reisdocumenten-gba.feature
+++ b/features/zoek-met-burgerservicenummer/gba/actuele-reisdocumenten-gba.feature
@@ -21,17 +21,16 @@ Functionaliteit: zoeken van de actuele reisdocumenten van een persoon met behulp
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | reisdocumentnummer         |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | reisdocumentnummer         |
       Dan heeft de response 0 reisdocumenten
 
       Voorbeelden:
-      | aanduiding | omschrijving                                                |
-      | I          | reisdocument ingeleverd                                     |
-      | V          | vermist reisdocument                                        |
+      | aanduiding | omschrijving            |
+      | I          | reisdocument ingeleverd |
+      | V          | vermist reisdocument    |
 
     Abstract Scenario: de persoon heeft een <omschrijving> en heeft geen ander reisdocument
       Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
@@ -46,11 +45,10 @@ Functionaliteit: zoeken van de actuele reisdocumenten van een persoon met behulp
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | reisdocumentnummer         |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | reisdocumentnummer         |
       Dan heeft de response 1 reisdocumenten
 
       Voorbeelden:
@@ -60,13 +58,13 @@ Functionaliteit: zoeken van de actuele reisdocumenten van een persoon met behulp
 
     Scenario: de persoon heeft een reisdocument ingeleverd en heeft een ander reisdocument van dezelfde soort nog in bezit
       Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-      | naam                                                                    | waarde       |
-      | soort reisdocument (35.10)                                              | PN           |
-      | nummer reisdocument (35.20)                                             | NE3663258    |
-      | datum uitgifte Nederlands reisdocument (35.30)                          | 20131106     |
-      | datum einde geldigheid reisdocument (35.50)                             | 20231106     |
-      | datum inhouding dan wel vermissing Nederlands reisdocument (35.60)      | 20221229     |
-      | aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70) | I            |
+      | naam                                                                    | waarde    |
+      | soort reisdocument (35.10)                                              | PN        |
+      | nummer reisdocument (35.20)                                             | NE3663258 |
+      | datum uitgifte Nederlands reisdocument (35.30)                          | 20131106  |
+      | datum einde geldigheid reisdocument (35.50)                             | 20231106  |
+      | datum inhouding dan wel vermissing Nederlands reisdocument (35.60)      | 20221229  |
+      | aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70) | I         |
       En de persoon heeft een 'reisdocument' met de volgende gegevens
       | naam                                           | waarde    |
       | soort reisdocument (35.10)                     | PN        |
@@ -77,11 +75,10 @@ Functionaliteit: zoeken van de actuele reisdocumenten van een persoon met behulp
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | reisdocumentnummer         |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | reisdocumentnummer         |
       Dan heeft de response 1 reisdocumenten
       En heeft de response een 'reisdocument' met de volgende gegevens
       | naam               | waarde    |
@@ -93,11 +90,11 @@ Functionaliteit: zoeken van de actuele reisdocumenten van een persoon met behulp
 
     Scenario: de persoon staat in het Register paspoortsignaleringen
       Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-      | naam                                                                    | waarde       |
-      | soort reisdocument (35.10)                                              | PN           |
-      | nummer reisdocument (35.20)                                             | NE3663258    |
-      | datum uitgifte Nederlands reisdocument (35.30)                          | 20171106     |
-      | datum einde geldigheid reisdocument (35.50)                             | 20271106     |
+      | naam                                           | waarde    |
+      | soort reisdocument (35.10)                     | PN        |
+      | nummer reisdocument (35.20)                    | NE3663258 |
+      | datum uitgifte Nederlands reisdocument (35.30) | 20171106  |
+      | datum einde geldigheid reisdocument (35.50)    | 20271106  |
       En de persoon heeft een 'reisdocument' met de volgende gegevens 
       | naam                                                                                   | waarde           |
       | signalering met betrekking tot het verstrekken van een Nederlands reisdocument (36.10) | 1                |
@@ -110,9 +107,8 @@ Functionaliteit: zoeken van de actuele reisdocumenten van een persoon met behulp
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | reisdocumentnummer         |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | reisdocumentnummer         |
       Dan heeft de response 1 reisdocumenten

--- a/features/zoek-met-burgerservicenummer/gba/autorisatie-gba.feature
+++ b/features/zoek-met-burgerservicenummer/gba/autorisatie-gba.feature
@@ -9,11 +9,10 @@ Functionaliteit: autorisatie voor het gebruik van de API ZoekMetBurgerservicenum
   Deze feature beschrijft alleen de autorisatie van de afnemer door RvIG.
 
   Voorlopig wordt de reisdocumenten bevragen API alleen aangeboden aan gemeenten voor het raadplegen van reisdocumenten van eigen inwoners.
-  Gebruikers zijn daarom verplicht om de parameter gemeenteVanInschrijving te gebruiken en mogen dan alleen de gemeentecode van de eigen gemeente gebruiken.
 
   Autorisatie wordt verkregen met behulp van een OAuth 2 token. 
   In het verkregen token is de afnemerindicatie opgenomen die de afnemer uniek identificeert. Op basis van de afnemerindicatie kan de autorisatie worden opgezocht.
-  Wanneer de afnemer een gemeente is, is er ook een gemeentecode opgenomen in de OAuth token.
+  Wanneer de afnemer een gemeente is, is er ook een gemeentecode opgenomen in de OAuth token. Deze wordt gebruikt om te bepalen of de houder van de gezochte reisdocument(en) een eigen inwoner is.
 
   Voor één afnemer kunnen er meerdere rijen zijn in de autorisatietabel, maar daarvan kan er maar één actueel zijn. Alleen de actuele mag worden gebruikt.
   Een autorisatie is actueel wanneer de Datum ingang (35.99.98) in het verleden ligt en Datum beëindiging tabelregel (35.99.99) leeg is of in de toekomst ligt.
@@ -26,10 +25,10 @@ Functionaliteit: autorisatie voor het gebruik van de API ZoekMetBurgerservicenum
 
     Achtergrond:
       Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-      | naam                                                                    | waarde    |
-      | soort reisdocument (35.10)                                              | PN        |
-      | nummer reisdocument (35.20)                                             | NE3663258 |
-      | datum einde geldigheid reisdocument (35.50)                             | 20240506  |
+      | naam                                        | waarde    |
+      | soort reisdocument (35.10)                  | PN        |
+      | nummer reisdocument (35.20)                 | NE3663258 |
+      | datum einde geldigheid reisdocument (35.50) | 20240506  |
       En de persoon heeft de volgende 'verblijfplaats' gegevens
       | gemeente van inschrijving (09.10) |
       | 0800                              |
@@ -40,71 +39,7 @@ Functionaliteit: autorisatie voor het gebruik van de API ZoekMetBurgerservicenum
     en die is gelijk aan de waarde van gemeenteCode in de 'claim', 
     dan wordt niet gekeken naar de autorisatie van de afnemer
 
-    Scenario: Gemeente zoekt reisdocumenten van een eigen inwoner door het opgeven van eigen gemeentecode als gemeenteVanInschrijving
-      Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
-      | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
-      | 10120                           | N                        | 20201128                |
-      En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
-      | gemeenteCode | 0800   |
-      Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                                                                     |
-      | type                    | ZoekMetBurgerservicenummer                                                 |
-      | burgerservicenummer     | 000000152                                                                  |
-      | gemeenteVanInschrijving | 0800                                                                       |
-      | fields                  | reisdocumentnummer,soort,datumEindeGeldigheid,inhoudingOfVermissing,houder |
-      Dan heeft de response 1 reisdocument
-
-    @fout-case
-    Scenario: Gemeente zoekt een reisdocument voor een inwoner van een andere gemeente met parameter gemeenteVanInschrijving
-      Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
-      | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
-      | 10120                           | N                        | 20201128                |
-      En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
-      | gemeenteCode | 0800   |
-      Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                                                                     |
-      | type                    | ZoekMetBurgerservicenummer                                                 |
-      | burgerservicenummer     | 000000152                                                                  |
-      | gemeenteVanInschrijving | 0599                                                                       |
-      | fields                  | reisdocumentnummer,soort,datumEindeGeldigheid,inhoudingOfVermissing,houder |
-      Dan heeft de response een object met de volgende gegevens
-      | naam     | waarde                                                                      |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                 |
-      | title    | U bent niet geautoriseerd voor deze vraag.                                  |
-      | status   | 403                                                                         |
-      | detail   | Je mag alleen reisdocumenten van inwoners uit de eigen gemeente raadplegen. |
-      | code     | unauthorized                                                                |
-      | instance | /haalcentraal/api/reisdocumenten/reisdocumenten                             |
-  
-    Scenario: Gemeente zoekt reisdocumenten van een inwonder van een andere gemeente en geeft zijn eigen gemeentecode op als gemeenteVanInschrijving
-      Gegeven de persoon met burgerservicenummer '000000024' heeft een 'reisdocument' met de volgende gegevens
-      | naam                        | waarde    |
-      | soort reisdocument (35.10)  | NI        |
-      | nummer reisdocument (35.20) | ID123NL45 |
-      En de persoon heeft de volgende 'verblijfplaats' gegevens
-      | gemeente van inschrijving (09.10) |
-      | 0530                              |
-      En de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
-      | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
-      | 10120                           | N                        | 20201128                |
-      En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
-      | gemeenteCode | 0800   |
-      Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                         |
-      | type                    | RaadpleegMetReisdocumentnummer |
-      | reisdocumentnummer      | ID123NL45                      |
-      | gemeenteVanInschrijving | 0800                           |
-      | fields                  | reisdocumentnummer             |
-      Dan heeft de response 0 reisdocumenten
-
-    @fout-case
-    Scenario: Gebruik van de parameter gemeenteVanInschrijving is verplicht
+    Scenario: Gemeente zoekt reisdocumenten van een eigen inwoner. 'gemeentecode' claim komt overeen met 'gemeente van inschrijving' van houder
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
       | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
       | 10120                           | N                        | 20201128                |
@@ -117,14 +52,27 @@ Functionaliteit: autorisatie voor het gebruik van de API ZoekMetBurgerservicenum
       | type                | ZoekMetBurgerservicenummer                                                 |
       | burgerservicenummer | 000000152                                                                  |
       | fields              | reisdocumentnummer,soort,datumEindeGeldigheid,inhoudingOfVermissing,houder |
+      Dan heeft de response 1 reisdocument
+
+    @fout-case
+    Scenario: Gemeente zoekt een reisdocument voor een inwoner van een andere gemeente
+      Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
+      | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
+      | 10120                           | N                        | 20201128                |
+      En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
+      | naam         | waarde |
+      | afnemerID    | 000008 |
+      | gemeenteCode | 0599   |
+      Als gba reisdocumenten wordt gezocht met de volgende parameters
+      | naam                | waarde                                                                     |
+      | type                | ZoekMetBurgerservicenummer                                                 |
+      | burgerservicenummer | 000000152                                                                  |
+      | fields              | reisdocumentnummer,soort,datumEindeGeldigheid,inhoudingOfVermissing,houder |
       Dan heeft de response een object met de volgende gegevens
-      | naam     | waarde                                                      |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-      | title    | Een of meerdere parameters zijn niet correct.               |
-      | status   | 400                                                         |
-      | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-      | code     | paramsValidation                                            |
-      | instance | /haalcentraal/api/reisdocumenten/reisdocumenten             |
-      En heeft het object de volgende 'invalidParams' gegevens
-      | code     | name                    | reason                  |
-      | required | gemeenteVanInschrijving | Parameter is verplicht. |
+      | naam     | waarde                                                                      |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                 |
+      | title    | U bent niet geautoriseerd voor deze vraag.                                  |
+      | status   | 403                                                                         |
+      | detail   | Je mag alleen reisdocumenten van inwoners uit de eigen gemeente raadplegen. |
+      | code     | unauthorized                                                                |
+      | instance | /haalcentraal/api/reisdocumenten/reisdocumenten                             |

--- a/features/zoek-met-burgerservicenummer/gba/autorisatie-gba.feature
+++ b/features/zoek-met-burgerservicenummer/gba/autorisatie-gba.feature
@@ -35,9 +35,6 @@ Functionaliteit: autorisatie voor het gebruik van de API ZoekMetBurgerservicenum
 
 
   Rule: Een gemeente als afnemer is geautoriseerd voor alle zoekvragen en alle gegevens voor haar eigen inwoners
-    Wanneer de afnemer parameter gemeenteVanInschrijving gebruikt 
-    en die is gelijk aan de waarde van gemeenteCode in de 'claim', 
-    dan wordt niet gekeken naar de autorisatie van de afnemer
 
     Scenario: Gemeente zoekt reisdocumenten van een eigen inwoner. 'gemeentecode' claim komt overeen met 'gemeente van inschrijving' van houder
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens

--- a/features/zoek-met-burgerservicenummer/gba/fout-cases-gba.feature
+++ b/features/zoek-met-burgerservicenummer/gba/fout-cases-gba.feature
@@ -8,10 +8,9 @@ Rule: De burgerservicenummer parameter is een verplichte parameter
   @fout-case
   Scenario: De burgerservicenummer parameter is niet opgegeven
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer         |
+    | naam   | waarde                     |
+    | type   | ZoekMetBurgerservicenummer |
+    | fields | reisdocumentnummer         |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -30,11 +29,10 @@ Rule: Een burgerservicenummer is een string bestaande uit exact 9 cijfers
   @fout-case
   Abstract Scenario: <titel>
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | <burgerservicenummer>      |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer         |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | <burgerservicenummer>      |
+    | fields              | reisdocumentnummer         |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -52,54 +50,3 @@ Rule: Een burgerservicenummer is een string bestaande uit exact 9 cijfers
     | 12345678            | De opgegeven burgerservicenummer is een string met minder dan negen cijfers |
     | 1234567890          | De opgegeven burgerservicenummer is een string met meer dan negen cijfers   |
     | 12345678X           | De opgegeven burgerservicenummer is een string met een letter               |
-
-
-Rule: De gemeenteVanInschrijving parameter is een verplichte parameter
-
-  @fout-case
-  Scenario: De gemeenteVanInschrijving parameter is niet opgegeven
-    Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                | waarde                     |
-    | type                | ZoekMetBurgerservicenummer |
-    | burgerservicenummer | 123456789                  |
-    | fields              | reisdocumentnummer         |
-    Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Een of meerdere parameters zijn niet correct.               |
-    | status   | 400                                                         |
-    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-    | code     | paramsValidation                                            |
-    | instance | /haalcentraal/api/reisdocumenten/reisdocumenten             |
-    En heeft het object de volgende 'invalidParams' gegevens
-    | code     | name                    | reason                  |
-    | required | gemeenteVanInschrijving | Parameter is verplicht. |
-
-Rule: Een gemeenteVanInschrijving is een string bestaande uit exact 4 cijfers
-
-  @fout-case
-  Abstract Scenario: <titel>
-    Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 123456789                  |
-    | gemeenteVanInschrijving | <gemeenteVanInschrijving>  |
-    | fields                  | reisdocumentnummer         |
-    Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Een of meerdere parameters zijn niet correct.               |
-    | status   | 400                                                         |
-    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-    | code     | paramsValidation                                            |
-    | instance | /haalcentraal/api/reisdocumenten/reisdocumenten             |
-    En heeft het object de volgende 'invalidParams' gegevens
-    | code    | name                    | reason                                      |
-    | pattern | gemeenteVanInschrijving | Waarde voldoet niet aan patroon ^[0-9]{4}$. |
-
-    Voorbeelden:
-    | gemeenteVanInschrijving | titel                                                                          |
-    | 123                     | De opgegeven gemeenteVanInschrijving is een string met minder dan vier cijfers |
-    | 12345                   | De opgegeven gemeenteVanInschrijving is een string met meer dan vier cijfers   |
-    | 123X                    | De opgegeven gemeenteVanInschrijving is een string met een letter              |
-    | 12.4                    | De opgegeven gemeenteVanInschrijving bevat niet-cijfer                         |

--- a/features/zoek-met-burgerservicenummer/gba/in-onderzoek-gba.feature
+++ b/features/zoek-met-burgerservicenummer/gba/in-onderzoek-gba.feature
@@ -5,21 +5,20 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
 
   Abstract Scenario: '<type>' is in onderzoek en de velden reisdocumentnummer en soort worden gevraagd
     Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-    | naam                                                                    | waarde                    |
-    | soort reisdocument (35.10)                                              | PN                        |
-    | nummer reisdocument (35.20)                                             | NE3663258                 |
-    | datum einde geldigheid reisdocument (35.50)                             | 20240506                  |
-    | aanduiding in onderzoek (83.10)                                         | <aanduiding in onderzoek> |
-    | datum ingang onderzoek (83.20)                                          | 20230201                  |
+    | naam                                        | waarde                    |
+    | soort reisdocument (35.10)                  | PN                        |
+    | nummer reisdocument (35.20)                 | NE3663258                 |
+    | datum einde geldigheid reisdocument (35.50) | 20240506                  |
+    | aanduiding in onderzoek (83.10)             | <aanduiding in onderzoek> |
+    | datum ingang onderzoek (83.20)              | 20230201                  |
     En de persoon heeft de volgende 'verblijfplaats' gegevens
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer,soort   |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | reisdocumentnummer,soort   |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam                                      | waarde                    |
     | reisdocumentnummer                        | NE3663258                 |
@@ -54,11 +53,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | houder                     |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | houder                     |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                                      | waarde                    |
     | burgerservicenummer                       | 000000152                 |
@@ -87,11 +85,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | <fields>                   |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | <fields>                   |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                                      | waarde    |
     | burgerservicenummer                       | 000000152 |
@@ -115,11 +112,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | houder                     |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | houder                     |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                | waarde    |
     | burgerservicenummer | 000000152 |
@@ -145,11 +141,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als gba reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer,soort   |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | reisdocumentnummer,soort   |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde             |
     | reisdocumentnummer | NE3663258          |

--- a/features/zoek-met-burgerservicenummer/gba/protocollering-gba.feature
+++ b/features/zoek-met-burgerservicenummer/gba/protocollering-gba.feature
@@ -39,7 +39,7 @@ Functionaliteit: Protocolleren van ZoekMetBurgerservicenummer
       | fields              | reisdocumentnummer,inhoudingOfVermissing |
       Dan heeft de persoon met burgerservicenummer '000000012' de volgende 'protocollering' gegevens
       | request_zoek_rubrieken |
-      | 010120, 080910         |
+      | 010120                 |
 
   Rule: Gevraagde velden in fields worden vertaald naar rubrieknummers, oplopend gesorteerd en gescheiden door komma en spatie
 

--- a/features/zoek-met-burgerservicenummer/gba/protocollering-gba.feature
+++ b/features/zoek-met-burgerservicenummer/gba/protocollering-gba.feature
@@ -33,11 +33,10 @@ Functionaliteit: Protocolleren van ZoekMetBurgerservicenummer
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                                   |
-      | type                    | ZoekMetBurgerservicenummer               |
-      | burgerservicenummer     | 000000012                                |
-      | gemeenteVanInschrijving | 0800                                     |
-      | fields                  | reisdocumentnummer,inhoudingOfVermissing |
+      | naam                | waarde                                   |
+      | type                | ZoekMetBurgerservicenummer               |
+      | burgerservicenummer | 000000012                                |
+      | fields              | reisdocumentnummer,inhoudingOfVermissing |
       Dan heeft de persoon met burgerservicenummer '000000012' de volgende 'protocollering' gegevens
       | request_zoek_rubrieken |
       | 010120, 080910         |
@@ -54,11 +53,10 @@ Functionaliteit: Protocolleren van ZoekMetBurgerservicenummer
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000012                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | <fields>                   |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000012                  |
+      | fields              | <fields>                   |
       Dan heeft de persoon met burgerservicenummer '000000012' de volgende 'protocollering' gegevens
       | request_gevraagde_rubrieken |
       | <gevraagde rubrieken>       |

--- a/features/zoek-met-burgerservicenummer/gba/reisdocumentnummer-standaardwaarde-gba.feature
+++ b/features/zoek-met-burgerservicenummer/gba/reisdocumentnummer-standaardwaarde-gba.feature
@@ -7,19 +7,18 @@ Functionaliteit: Reisdocumentnummer met standaardwaarde
 
     Scenario: Reisdocumentnummer heeft de standaardwaarde
       Gegeven de persoon met burgerservicenummer '000000024' heeft een 'reisdocument' met de volgende gegevens
-      | naam                                            | waarde    |
-      | soort reisdocument (35.10)                      | PN        |
-      | nummer reisdocument (35.20)                     | ......... |
-      | datum einde geldigheid reisdocument (35.50)     | 20330506  |
+      | naam                                        | waarde    |
+      | soort reisdocument (35.10)                  | PN        |
+      | nummer reisdocument (35.20)                 | ......... |
+      | datum einde geldigheid reisdocument (35.50) | 20330506  |
       En de persoon heeft de volgende 'verblijfplaats' gegevens
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000024                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | reisdocumentnummer         |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000024                  |
+      | fields              | reisdocumentnummer         |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam               | waarde    |
       | reisdocumentnummer | ......... |

--- a/features/zoek-met-burgerservicenummer/gba/soort-reisdocument-gba.feature
+++ b/features/zoek-met-burgerservicenummer/gba/soort-reisdocument-gba.feature
@@ -14,11 +14,10 @@ Functionaliteit: Soort reisdocument
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000024                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | soort                      |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000024                  |
+      | fields              | soort                      |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam               | waarde         |
       | soort.code         | <code>         |

--- a/features/zoek-met-burgerservicenummer/geheimhouding/gba/overzicht-gba.feature
+++ b/features/zoek-met-burgerservicenummer/geheimhouding/gba/overzicht-gba.feature
@@ -8,10 +8,10 @@ Functionaliteit: gba geheimhouding leveren bij ZoekMetBurgerservicenummer
 
   Achtergrond:
       Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-      | naam                                            | waarde    |
-      | soort reisdocument (35.10)                      | PN        |
-      | nummer reisdocument (35.20)                     | NE3663258 |
-      | datum einde geldigheid reisdocument (35.50)     | 20330506  |
+      | naam                                        | waarde    |
+      | soort reisdocument (35.10)                  | PN        |
+      | nummer reisdocument (35.20)                 | NE3663258 |
+      | datum einde geldigheid reisdocument (35.50) | 20330506  |
       En de persoon heeft de volgende 'verblijfplaats' gegevens
       | gemeente van inschrijving (09.10) |
       | 0800                              |
@@ -24,11 +24,10 @@ Functionaliteit: gba geheimhouding leveren bij ZoekMetBurgerservicenummer
       | naam                     | waarde |
       | indicatie geheim (70.10) | 0      |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | reisdocumentnummer         |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | reisdocumentnummer         |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam               | waarde    |
       | reisdocumentnummer | NE3663258 |
@@ -41,11 +40,10 @@ Functionaliteit: gba geheimhouding leveren bij ZoekMetBurgerservicenummer
       | naam                     | waarde   |
       | indicatie geheim (70.10) | <waarde> |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | reisdocumentnummer         |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | reisdocumentnummer         |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam                                 | waarde    |
       | reisdocumentnummer                   | NE3663258 |
@@ -66,11 +64,10 @@ Functionaliteit: gba geheimhouding leveren bij ZoekMetBurgerservicenummer
       | naam                     | waarde |
       | indicatie geheim (70.10) | 7      |
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | <fields>                   |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | <fields>                   |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam                                 | waarde     |
       | <veld 1>                             | <waarde 1> |
@@ -93,11 +90,10 @@ Functionaliteit: gba geheimhouding leveren bij ZoekMetBurgerservicenummer
     @fout-case
     Abstract Scenario: veld geheimhoudingPersoonsgegevens mag niet worden gevraagd, omdat het automatisch wordt geleverd
       Als gba reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | <fields>                   |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | <fields>                   |
       Dan heeft de response een object met de volgende gegevens
       | naam     | waarde                                                      |
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -111,7 +107,7 @@ Functionaliteit: gba geheimhouding leveren bij ZoekMetBurgerservicenummer
       | fields | fields[<index>] | Parameter bevat een niet toegestane veldnaam. |
 
       Voorbeelden:
-      | fields                                                                                   | index |
-      | houder.geheimhoudingPersoonsgegevens                                                     | 0     |
-      | reisdocumentnummer,houder.geheimhoudingPersoonsgegevens,houder.burgerservicenummer       | 1     |
-      | soort,inhoudingOfVermissing.datum,houder.geheimhoudingPersoonsgegevens                   | 2     |
+      | fields                                                                             | index |
+      | houder.geheimhoudingPersoonsgegevens                                               | 0     |
+      | reisdocumentnummer,houder.geheimhoudingPersoonsgegevens,houder.burgerservicenummer | 1     |
+      | soort,inhoudingOfVermissing.datum,houder.geheimhoudingPersoonsgegevens             | 2     |

--- a/features/zoek-met-burgerservicenummer/geheimhouding/overzicht.feature
+++ b/features/zoek-met-burgerservicenummer/geheimhouding/overzicht.feature
@@ -7,10 +7,10 @@ Functionaliteit: geheimhouding leveren bij ZoekMetBurgerservicenummer
 
   Achtergrond:
       Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-      | naam                                            | waarde    |
-      | soort reisdocument (35.10)                      | PN        |
-      | nummer reisdocument (35.20)                     | NE3663258 |
-      | datum einde geldigheid reisdocument (35.50)     | 20330506  |
+      | naam                                        | waarde    |
+      | soort reisdocument (35.10)                  | PN        |
+      | nummer reisdocument (35.20)                 | NE3663258 |
+      | datum einde geldigheid reisdocument (35.50) | 20330506  |
       En de persoon heeft de volgende 'verblijfplaats' gegevens
       | gemeente van inschrijving (09.10) |
       | 0800                              |
@@ -23,11 +23,10 @@ Functionaliteit: geheimhouding leveren bij ZoekMetBurgerservicenummer
       | naam                     | waarde |
       | indicatie geheim (70.10) | 0      |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | reisdocumentnummer         |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | reisdocumentnummer         |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam               | waarde    |
       | reisdocumentnummer | NE3663258 |
@@ -40,11 +39,10 @@ Functionaliteit: geheimhouding leveren bij ZoekMetBurgerservicenummer
       | naam                     | waarde   |
       | indicatie geheim (70.10) | <waarde> |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | reisdocumentnummer         |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | reisdocumentnummer         |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam                                 | waarde    |
       | reisdocumentnummer                   | NE3663258 |
@@ -65,11 +63,10 @@ Functionaliteit: geheimhouding leveren bij ZoekMetBurgerservicenummer
       | naam                     | waarde |
       | indicatie geheim (70.10) | 7      |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | <fields>                   |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | <fields>                   |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam                                 | waarde     |
       | <veld 1>                             | <waarde 1> |
@@ -94,11 +91,10 @@ Functionaliteit: geheimhouding leveren bij ZoekMetBurgerservicenummer
     @fout-case
     Abstract Scenario: veld geheimhoudingPersoonsgegevens mag niet worden gevraagd, omdat het automatisch wordt geleverd
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000152                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | <fields>                   |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                  |
+      | fields              | <fields>                   |
       Dan heeft de response een object met de volgende gegevens
       | naam     | waarde                                                      |
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -112,7 +108,7 @@ Functionaliteit: geheimhouding leveren bij ZoekMetBurgerservicenummer
       | fields | fields[<index>] | Parameter bevat een niet toegestane veldnaam. |
 
       Voorbeelden:
-      | fields                                                                                   | index |
-      | houder.geheimhoudingPersoonsgegevens                                                     | 0     |
-      | reisdocumentnummer,houder.geheimhoudingPersoonsgegevens,houder.burgerservicenummer       | 1     |
-      | soort,inhoudingOfVermissing.datum,houder.geheimhoudingPersoonsgegevens                   | 2     |
+      | fields                                                                             | index |
+      | houder.geheimhoudingPersoonsgegevens                                               | 0     |
+      | reisdocumentnummer,houder.geheimhoudingPersoonsgegevens,houder.burgerservicenummer | 1     |
+      | soort,inhoudingOfVermissing.datum,houder.geheimhoudingPersoonsgegevens             | 2     |

--- a/features/zoek-met-burgerservicenummer/in-onderzoek.feature
+++ b/features/zoek-met-burgerservicenummer/in-onderzoek.feature
@@ -4,21 +4,20 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
 
   Abstract Scenario: '<type>' is in onderzoek en de velden reisdocumentnummer, soort en datumEindeGeldigheid worden gevraagd
     Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-    | naam                                                                    | waarde                    |
-    | soort reisdocument (35.10)                                              | PN                        |
-    | nummer reisdocument (35.20)                                             | NE3663258                 |
-    | datum einde geldigheid reisdocument (35.50)                             | 20240506                  |
-    | aanduiding in onderzoek (83.10)                                         | <aanduiding in onderzoek> |
-    | datum ingang onderzoek (83.20)                                          | 20230506                  |
+    | naam                                        | waarde                    |
+    | soort reisdocument (35.10)                  | PN                        |
+    | nummer reisdocument (35.20)                 | NE3663258                 |
+    | datum einde geldigheid reisdocument (35.50) | 20240506                  |
+    | aanduiding in onderzoek (83.10)             | <aanduiding in onderzoek> |
+    | datum ingang onderzoek (83.20)              | 20230506                  |
     En de persoon heeft de volgende 'verblijfplaats' gegevens
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                                        |
-    | type                    | ZoekMetBurgerservicenummer                    |
-    | burgerservicenummer     | 000000152                                     |
-    | gemeenteVanInschrijving | 0800                                          |
-    | fields                  | reisdocumentnummer,soort,datumEindeGeldigheid |
+    | naam                | waarde                                        |
+    | type                | ZoekMetBurgerservicenummer                    |
+    | burgerservicenummer | 000000152                                     |
+    | fields              | reisdocumentnummer,soort,datumEindeGeldigheid |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam                                         | waarde                      |
     | reisdocumentnummer                           | NE3663258                   |
@@ -44,21 +43,20 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
 
   Abstract Scenario: '<type>' is in onderzoek en de velden reisdocumentnummer, soort en datumEindeGeldigheid worden gevraagd
     Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-    | naam                                                                    | waarde                    |
-    | soort reisdocument (35.10)                                              | PN                        |
-    | nummer reisdocument (35.20)                                             | NE3663258                 |
-    | datum einde geldigheid reisdocument (35.50)                             | 20240506                  |
-    | aanduiding in onderzoek (83.10)                                         | <aanduiding in onderzoek> |
-    | datum ingang onderzoek (83.20)                                          | 20230506                  |
+    | naam                                        | waarde                    |
+    | soort reisdocument (35.10)                  | PN                        |
+    | nummer reisdocument (35.20)                 | NE3663258                 |
+    | datum einde geldigheid reisdocument (35.50) | 20240506                  |
+    | aanduiding in onderzoek (83.10)             | <aanduiding in onderzoek> |
+    | datum ingang onderzoek (83.20)              | 20230506                  |
     En de persoon heeft de volgende 'verblijfplaats' gegevens
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                                        |
-    | type                    | ZoekMetBurgerservicenummer                    |
-    | burgerservicenummer     | 000000152                                     |
-    | gemeenteVanInschrijving | 0800                                          |
-    | fields                  | reisdocumentnummer,soort,datumEindeGeldigheid |
+    | naam                | waarde                                        |
+    | type                | ZoekMetBurgerservicenummer                    |
+    | burgerservicenummer | 000000152                                     |
+    | fields              | reisdocumentnummer,soort,datumEindeGeldigheid |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam                             | waarde             |
     | reisdocumentnummer               | NE3663258          |
@@ -89,11 +87,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | houder                     |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | houder                     |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                                         | waarde          |
     | burgerservicenummer                          | 000000152       |
@@ -122,11 +119,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | <fields>                   |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | <fields>                   |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                                         | waarde          |
     | burgerservicenummer                          | 000000152       |
@@ -154,11 +150,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | houder                     |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | houder                     |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                | waarde    |
     | burgerservicenummer | 000000152 |
@@ -180,11 +175,10 @@ Functionaliteit: Reisdocument velden zijn in onderzoek
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | houder                     |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | houder                     |
     Dan heeft de response een 'reisdocument' met de volgende 'houder' gegevens
     | naam                | waarde    |
     | burgerservicenummer | 000000152 |

--- a/features/zoek-met-burgerservicenummer/overzicht.feature
+++ b/features/zoek-met-burgerservicenummer/overzicht.feature
@@ -14,11 +14,10 @@ Rule: voor het zoeken van reisdocumenten van een persoon moet het burgerservicen
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer         |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | reisdocumentnummer         |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde    |
     | reisdocumentnummer | NE3663258 |
@@ -38,11 +37,10 @@ Rule: voor het zoeken van reisdocumenten van een persoon moet het burgerservicen
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer         |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | reisdocumentnummer         |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde    |
     | reisdocumentnummer | NE3663258 |
@@ -55,53 +53,50 @@ Rule: voor het zoeken van reisdocumenten van een persoon moet het burgerservicen
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 987654321                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer,houder  |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 987654321                  |
+    | fields              | reisdocumentnummer,houder  |
     Dan heeft de response 0 reisdocumenten
 
   Scenario: de gezochte persoon bestaat niet
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 987654321                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer,houder  |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 987654321                  |
+    | fields              | reisdocumentnummer,houder  |
     Dan heeft de response 0 reisdocumenten
 
 Rule: bij zoeken van reisdocumenten met burgerservicenummer worden alleen reisdocumenten geleverd die volgens de registratie nog in het bezit zijn van de persoon
 
   Scenario: de gezochte persoon heeft het reisdocument ingeleverd
     Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-    | naam                                                                    | waarde       |
-    | soort reisdocument (35.10)                                              | PN           |
-    | nummer reisdocument (35.20)                                             | NE3663258    |
-    | datum uitgifte Nederlands reisdocument (35.30)                          | 20131106     |
-    | datum einde geldigheid reisdocument (35.50)                             | 20231106     |
-    | datum inhouding dan wel vermissing Nederlands reisdocument (35.60)      | 20221229     |
-    | aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70) | I            |
+    | naam                                                                    | waarde    |
+    | soort reisdocument (35.10)                                              | PN        |
+    | nummer reisdocument (35.20)                                             | NE3663258 |
+    | datum uitgifte Nederlands reisdocument (35.30)                          | 20131106  |
+    | datum einde geldigheid reisdocument (35.50)                             | 20231106  |
+    | datum inhouding dan wel vermissing Nederlands reisdocument (35.60)      | 20221229  |
+    | aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70) | I         |
     En de persoon heeft de volgende 'verblijfplaats' gegevens
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 987654321                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer         |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 987654321                  |
+    | fields              | reisdocumentnummer         |
     Dan heeft de response 0 reisdocumenten
 
   Scenario: de gezochte persoon heeft meerdere reisdocumenten ingeleverd en heeft één reisdocument nog in bezit
     Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-    | naam                                                                    | waarde       |
-    | soort reisdocument (35.10)                                              | PN           |
-    | nummer reisdocument (35.20)                                             | NE3663258    |
-    | datum uitgifte Nederlands reisdocument (35.30)                          | 20131106     |
-    | datum einde geldigheid reisdocument (35.50)                             | 20231106     |
-    | datum inhouding dan wel vermissing Nederlands reisdocument (35.60)      | 20221229     |
-    | aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70) | I            |
+    | naam                                                                    | waarde    |
+    | soort reisdocument (35.10)                                              | PN        |
+    | nummer reisdocument (35.20)                                             | NE3663258 |
+    | datum uitgifte Nederlands reisdocument (35.30)                          | 20131106  |
+    | datum einde geldigheid reisdocument (35.50)                             | 20231106  |
+    | datum inhouding dan wel vermissing Nederlands reisdocument (35.60)      | 20221229  |
+    | aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70) | I         |
     En de persoon heeft een 'reisdocument' met de volgende gegevens
     | naam                                           | waarde    |
     | soort reisdocument (35.10)                     | PN        |
@@ -119,11 +114,10 @@ Rule: bij zoeken van reisdocumenten met burgerservicenummer worden alleen reisdo
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer         |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | reisdocumentnummer         |
     Dan heeft de response 1 reisdocumenten
     En heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde    |
@@ -131,13 +125,13 @@ Rule: bij zoeken van reisdocumenten met burgerservicenummer worden alleen reisdo
 
   Scenario: de gezochte persoon heeft reisdocumenten ingeleverd en vermist en heeft verschillende soorten reisdocumenten in bezit
     Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens
-    | naam                                                                    | waarde       |
-    | soort reisdocument (35.10)                                              | PN           |
-    | nummer reisdocument (35.20)                                             | NE3663258    |
-    | datum uitgifte Nederlands reisdocument (35.30)                          | 20131106     |
-    | datum einde geldigheid reisdocument (35.50)                             | 20231106     |
-    | datum inhouding dan wel vermissing Nederlands reisdocument (35.60)      | 20221229     |
-    | aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70) | I            |
+    | naam                                                                    | waarde    |
+    | soort reisdocument (35.10)                                              | PN        |
+    | nummer reisdocument (35.20)                                             | NE3663258 |
+    | datum uitgifte Nederlands reisdocument (35.30)                          | 20131106  |
+    | datum einde geldigheid reisdocument (35.50)                             | 20231106  |
+    | datum inhouding dan wel vermissing Nederlands reisdocument (35.60)      | 20221229  |
+    | aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70) | I         |
     En de persoon heeft een 'reisdocument' met de volgende gegevens
     | naam                                           | waarde    |
     | soort reisdocument (35.10)                     | PN        |
@@ -152,19 +146,18 @@ Rule: bij zoeken van reisdocumenten met burgerservicenummer worden alleen reisdo
     | datum inhouding dan wel vermissing Nederlands reisdocument (35.60)      | 20230205  |
     | aanduiding inhouding dan wel vermissing Nederlands reisdocument (35.70) | V         |
     En de persoon heeft een 'reisdocument' met de volgende gegevens
-    | naam                                                                    | waarde    |
-    | soort reisdocument (35.10)                                              | NI        |
-    | nummer reisdocument (35.20)                                             | ID23NW456 |
-    | datum einde geldigheid reisdocument (35.50)                             | 20330221  |
+    | naam                                        | waarde    |
+    | soort reisdocument (35.10)                  | NI        |
+    | nummer reisdocument (35.20)                 | ID23NW456 |
+    | datum einde geldigheid reisdocument (35.50) | 20330221  |
     En de persoon heeft de volgende 'verblijfplaats' gegevens
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer         |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | reisdocumentnummer         |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde    |
     | reisdocumentnummer | NWE45TN71 |
@@ -186,11 +179,10 @@ Rule: als een gevraagde veld in onderzoek is, dan wordt het bijbehorend inOnderz
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer,soort   |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | reisdocumentnummer,soort   |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam                                         | waarde             |
     | reisdocumentnummer                           | NE3663258          |
@@ -213,11 +205,10 @@ Rule: als een gevraagde veld in onderzoek is, dan wordt het bijbehorend inOnderz
     | gemeente van inschrijving (09.10) |
     | 0800                              |
     Als reisdocumenten wordt gezocht met de volgende parameters
-    | naam                    | waarde                     |
-    | type                    | ZoekMetBurgerservicenummer |
-    | burgerservicenummer     | 000000152                  |
-    | gemeenteVanInschrijving | 0800                       |
-    | fields                  | reisdocumentnummer         |
+    | naam                | waarde                     |
+    | type                | ZoekMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                  |
+    | fields              | reisdocumentnummer         |
     Dan heeft de response een 'reisdocument' met de volgende gegevens
     | naam               | waarde    |
     | reisdocumentnummer | NE3663258 |

--- a/features/zoek-met-burgerservicenummer/overzicht.feature
+++ b/features/zoek-met-burgerservicenummer/overzicht.feature
@@ -2,7 +2,7 @@
 
 Functionaliteit: Zoek met burgerservicenummer
 
-Rule: voor het zoeken van reisdocumenten van een persoon moet het burgerservicenummer en de gemeenteVanInschrijving worden opgegeven
+Rule: voor het zoeken van reisdocumenten van een persoon moet het burgerservicenummer worden opgegeven
 
   Scenario: de gezochte persoon heeft één reisdocument
     Gegeven de persoon met burgerservicenummer '000000152' heeft een 'reisdocument' met de volgende gegevens

--- a/features/zoek-met-burgerservicenummer/reisdocumentnummer-standaardwaarde.feature
+++ b/features/zoek-met-burgerservicenummer/reisdocumentnummer-standaardwaarde.feature
@@ -6,17 +6,16 @@ Functionaliteit: Reisdocumentnummer met standaardwaarde
 
     Scenario: Reisdocumentnummer heeft de standaardwaarde
       Gegeven de persoon met burgerservicenummer '000000024' heeft een 'reisdocument' met de volgende gegevens
-      | naam                                            | waarde    |
-      | soort reisdocument (35.10)                      | PN        |
-      | nummer reisdocument (35.20)                     | ......... |
-      | datum einde geldigheid reisdocument (35.50)     | 20330506  |
+      | naam                                        | waarde    |
+      | soort reisdocument (35.10)                  | PN        |
+      | nummer reisdocument (35.20)                 | ......... |
+      | datum einde geldigheid reisdocument (35.50) | 20330506  |
       En de persoon heeft de volgende 'verblijfplaats' gegevens
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000024                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | reisdocumentnummer         |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000024                  |
+      | fields              | reisdocumentnummer         |
       Dan heeft de response een 'reisdocument' zonder gegevens

--- a/features/zoek-met-burgerservicenummer/soort-reisdocument.feature
+++ b/features/zoek-met-burgerservicenummer/soort-reisdocument.feature
@@ -13,11 +13,10 @@ Functionaliteit: Soort reisdocument
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000024                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | soort                      |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000024                  |
+      | fields              | soort                      |
       Dan heeft de response een 'reisdocument' met de volgende gegevens
       | naam               | waarde         |
       | soort.code         | <code>         |
@@ -40,10 +39,9 @@ Functionaliteit: Soort reisdocument
       | gemeente van inschrijving (09.10) |
       | 0800                              |
       Als reisdocumenten wordt gezocht met de volgende parameters
-      | naam                    | waarde                     |
-      | type                    | ZoekMetBurgerservicenummer |
-      | burgerservicenummer     | 000000024                  |
-      | gemeenteVanInschrijving | 0800                       |
-      | fields                  | soort                      |
+      | naam                | waarde                     |
+      | type                | ZoekMetBurgerservicenummer |
+      | burgerservicenummer | 000000024                  |
+      | fields              | soort                      |
       Dan heeft de response een 'reisdocument' zonder gegevens
     

--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -275,7 +275,7 @@
         } ]
       },
       "ReisdocumentenQuery" : {
-        "required" : [ "fields", "gemeenteVanInschrijving", "type" ],
+        "required" : [ "fields", "type" ],
         "type" : "object",
         "properties" : {
           "type" : {
@@ -288,9 +288,6 @@
             "items" : {
               "$ref" : "#/components/schemas/Field"
             }
-          },
-          "gemeenteVanInschrijving" : {
-            "$ref" : "#/components/schemas/GemeenteVanInschrijving"
           }
         },
         "discriminator" : {
@@ -484,12 +481,6 @@
         "pattern" : "^[a-zA-Z0-9\\._]{1,200}$",
         "type" : "string",
         "description" : "Het pad naar een gewenst veld in punt-gescheiden formaat. Bijvoorbeeld \"burgerservicenummer\", \"geboorte.datum\", \"partners.naam.voornamen\".\n"
-      },
-      "GemeenteVanInschrijving" : {
-        "pattern" : "^[0-9]{4}$",
-        "type" : "string",
-        "description" : "Een code die aangeeft in welke gemeente de persoon woont, of de laatste gemeente waar de persoon heeft gewoond, of de gemeente waar de persoon voor het eerst is ingeschreven.\n",
-        "example" : "0518"
       },
       "Burgerservicenummer" : {
         "pattern" : "^[0-9]{9}$",

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -212,7 +212,6 @@ components:
     ReisdocumentenQuery:
       required:
       - fields
-      - gemeenteVanInschrijving
       - type
       type: object
       properties:
@@ -224,8 +223,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Field'
-        gemeenteVanInschrijving:
-          $ref: '#/components/schemas/GemeenteVanInschrijving'
       discriminator:
         propertyName: type
         mapping:
@@ -364,12 +361,6 @@ components:
       type: string
       description: |
         Het pad naar een gewenst veld in punt-gescheiden formaat. Bijvoorbeeld "burgerservicenummer", "geboorte.datum", "partners.naam.voornamen".
-    GemeenteVanInschrijving:
-      pattern: "^[0-9]{4}$"
-      type: string
-      description: |
-        Een code die aangeeft in welke gemeente de persoon woont, of de laatste gemeente waar de persoon heeft gewoond, of de gemeente waar de persoon voor het eerst is ingeschreven.
-      example: "0518"
     Burgerservicenummer:
       pattern: "^[0-9]{9}$"
       type: string

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -275,7 +275,7 @@
         } ]
       },
       "ReisdocumentenQuery" : {
-        "required" : [ "fields", "gemeenteVanInschrijving", "type" ],
+        "required" : [ "fields", "type" ],
         "type" : "object",
         "properties" : {
           "type" : {
@@ -288,9 +288,6 @@
             "items" : {
               "$ref" : "#/components/schemas/Field"
             }
-          },
-          "gemeenteVanInschrijving" : {
-            "$ref" : "#/components/schemas/GemeenteVanInschrijving"
           }
         },
         "discriminator" : {
@@ -529,12 +526,6 @@
         "pattern" : "^[a-zA-Z0-9\\._]{1,200}$",
         "type" : "string",
         "description" : "Het pad naar een gewenst veld in punt-gescheiden formaat. Bijvoorbeeld \"burgerservicenummer\", \"geboorte.datum\", \"partners.naam.voornamen\".\n"
-      },
-      "GemeenteVanInschrijving" : {
-        "pattern" : "^[0-9]{4}$",
-        "type" : "string",
-        "description" : "Een code die aangeeft in welke gemeente de persoon woont, of de laatste gemeente waar de persoon heeft gewoond, of de gemeente waar de persoon voor het eerst is ingeschreven.\n",
-        "example" : "0518"
       },
       "Burgerservicenummer" : {
         "pattern" : "^[0-9]{9}$",

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -212,7 +212,6 @@ components:
     ReisdocumentenQuery:
       required:
       - fields
-      - gemeenteVanInschrijving
       - type
       type: object
       properties:
@@ -224,8 +223,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Field'
-        gemeenteVanInschrijving:
-          $ref: '#/components/schemas/GemeenteVanInschrijving'
       discriminator:
         propertyName: type
         mapping:
@@ -393,12 +390,6 @@ components:
       type: string
       description: |
         Het pad naar een gewenst veld in punt-gescheiden formaat. Bijvoorbeeld "burgerservicenummer", "geboorte.datum", "partners.naam.voornamen".
-    GemeenteVanInschrijving:
-      pattern: "^[0-9]{4}$"
-      type: string
-      description: |
-        Een code die aangeeft in welke gemeente de persoon woont, of de laatste gemeente waar de persoon heeft gewoond, of de gemeente waar de persoon voor het eerst is ingeschreven.
-      example: "0518"
     Burgerservicenummer:
       pattern: "^[0-9]{9}$"
       type: string

--- a/specificatie/persoon.yaml
+++ b/specificatie/persoon.yaml
@@ -16,9 +16,3 @@ components:
       description: |
         Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.
       type: boolean
-    GemeenteVanInschrijving:
-      description: |
-        Een code die aangeeft in welke gemeente de persoon woont, of de laatste gemeente waar de persoon heeft gewoond, of de gemeente waar de persoon voor het eerst is ingeschreven.
-      type: string
-      pattern: ^[0-9]{4}$
-      example: "0518"

--- a/specificatie/zoek-gba-reisdocumenten.yaml
+++ b/specificatie/zoek-gba-reisdocumenten.yaml
@@ -62,7 +62,6 @@ components:
       required:
         - type
         - fields
-        - gemeenteVanInschrijving
       discriminator:
         propertyName: type
         mapping:
@@ -77,8 +76,6 @@ components:
           minItems: 1
           items:
             $ref: 'filter.yaml#/components/schemas/Field'
-        gemeenteVanInschrijving:
-          $ref: 'persoon.yaml#/components/schemas/GemeenteVanInschrijving'
     RaadpleegMetReisdocumentnummer:
       required:
         - reisdocumentnummer

--- a/specificatie/zoek-reisdocumenten.yaml
+++ b/specificatie/zoek-reisdocumenten.yaml
@@ -62,7 +62,6 @@ components:
       required:
         - type
         - fields
-        - gemeenteVanInschrijving
       discriminator:
         propertyName: type
         mapping:
@@ -77,8 +76,6 @@ components:
           minItems: 1
           items:
             $ref: 'filter.yaml#/components/schemas/Field'
-        gemeenteVanInschrijving:
-          $ref: 'persoon.yaml#/components/schemas/GemeenteVanInschrijving'
     RaadpleegMetReisdocumentnummer:
       required:
         - reisdocumentnummer


### PR DESCRIPTION
vraag: moet een foutmelding worden gegeven als de consumer reisdocumenten wil raadplegen van een inwoner van een ander gemeente of heeft de response geen reisdocumenten?